### PR TITLE
Updates GTFS tools

### DIFF
--- a/tools/_shared/inc/helpers/db_engine.py
+++ b/tools/_shared/inc/helpers/db_engine.py
@@ -18,6 +18,28 @@ class SQLiteDBEngine:
         self._db_handle = sqlite3.connect(conn_ds, uri=True)
         self._db_handle.row_factory = sqlite3.Row
         
+    def fetch_table_names(self):
+        table_names = []
+        
+        sql = "SELECT name FROM sqlite_master WHERE type ='table' AND name NOT LIKE 'sqlite_%';"
+        cursor = self._db_handle.cursor()
+        cursor.execute(sql)
+        for db_row in cursor:
+            table_name = db_row[0]
+            table_names.append(table_name)
+        cursor.close()
+
+        return table_names
+    
+    def compute_table_stats(self):
+        table_stats = {}
+        
+        table_names = self.fetch_table_names()
+        for table_name in table_names:
+            table_stats[table_name] = self.count_rows_table(table_name)
+            
+        return table_stats
+        
     def table_columns_names(self, table_name: str):
         sql = f"PRAGMA table_info({table_name})"
         columns_cursor = self._db_handle.cursor()
@@ -56,3 +78,7 @@ class SQLiteDBEngine:
             return map_row_items
         else:
             return row_items
+        
+    def count_rows_table(self, table_name: str, where_clause = None):
+        sql = f"SELECT COUNT(1) AS cno FROM {table_name} {where_clause}"
+        return self._db_handle.cursor().execute(sql).fetchone()[0]

--- a/tools/_shared/inc/helpers/db_engine.py
+++ b/tools/_shared/inc/helpers/db_engine.py
@@ -1,0 +1,58 @@
+import os, sys
+
+import sqlite3
+
+from pathlib import Path
+
+class SQLiteDBEngine:
+    def __init__(self, db_path: Path, is_read_only = True):
+        if isinstance(db_path, str):
+            db_path = Path(db_path)
+            
+        self.db_path = db_path
+        
+        conn_ds = f'file:{db_path}'
+        if is_read_only:
+            conn_ds = f'{conn_ds}?mode=ro'
+
+        self._db_handle = sqlite3.connect(conn_ds, uri=True)
+        self._db_handle.row_factory = sqlite3.Row
+        
+    def table_columns_names(self, table_name: str):
+        sql = f"PRAGMA table_info({table_name})"
+        columns_cursor = self._db_handle.cursor()
+        columns_cursor.execute(sql)
+        columns_db_rows = columns_cursor.fetchall()
+        columns_cursor.close()
+
+        column_names = []
+        for pragma_column_row in columns_db_rows:
+            column_name = pragma_column_row[1]
+            column_names.append(column_name)
+            
+        return column_names
+        
+    def query(self, sql: str, map_by_field: str = None):
+        row_items = []
+        map_row_items = {}
+
+        cursor = self._db_handle.cursor()
+        cursor.execute(sql)
+        
+        column_names = [description[0] for description in cursor.description]
+        
+        for db_row in cursor:
+            db_row_dict = {}
+            for column_idx, column_name in enumerate(column_names):
+                db_row_dict[column_name] = db_row[column_idx]
+            
+            if map_by_field:
+                map_row_items[db_row_dict[map_by_field]] = db_row_dict
+            else:
+                row_items.append(db_row_dict)
+        cursor.close()
+        
+        if map_by_field:
+            return map_row_items
+        else:
+            return row_items

--- a/tools/_shared/inc/helpers/gtfs_helpers.py
+++ b/tools/_shared/inc/helpers/gtfs_helpers.py
@@ -2,34 +2,25 @@ import os, sys
 import re
 import datetime
 
-from typing import Union
-
 from pathlib import Path
 
-def compute_formatted_date_from_gtfs_folder_path(folder_path: Path):
-    gtfs_filename_dt = compute_datetime_from_gtfs_resource_filename(folder_path)
-    if gtfs_filename_dt is None:
-        return None
-    
-    formatted_date = gtfs_filename_dt.strftime('%Y-%m-%d')
-    
-    return formatted_date
+from typing import Union
 
-def compute_datetime_from_gtfs_resource_filename(file_path: str) -> Union[datetime.datetime, None]:
-    if isinstance(file_path, str):
-        file_path = Path(file_path)
-        
+def compute_gtfs_day_from_resource_path(resource_path: Path):
+    if isinstance(resource_path, str):
+        resource_path = Path(resource_path)
+    
     # gtfs_fp2021_2021-02-17_09-10
     # GTFS_FP2024_2024-04-15_08-54.zip
-    dt_matches = re.match("^.+?[fpFP]([0-9]{4})_([0-9]{4})-([0-9]{2})-([0-9]{2})_([0-9]{2})-([0-9]{2}).*$", file_path.name)
-    
+    # GTFS_FP2024_2024-05-02
+    dt_matches = re.match("^gtfs_fp([0-9]{4})_([0-9]{4})-([0-9]{2})-([0-9]{2}).*$", resource_path.name.lower())
     if dt_matches is None:
         return None
     
-    file_dt_s = f'{dt_matches[2]}-{dt_matches[3]}-{dt_matches[4]} {dt_matches[5]}:{dt_matches[6]}'
-    file_dt = datetime.datetime.strptime(file_dt_s, '%Y-%m-%d %H:%M')
+    gtfs_day_f = f'{dt_matches[2]}-{dt_matches[3]}-{dt_matches[4]}'
+    gtfs_day = datetime.datetime.strptime(gtfs_day_f, '%Y-%m-%d').date()
     
-    return file_dt
+    return gtfs_day
 
 def convert_datetime_to_day_minutes(datetime_s: str):
     # fix HRDF bug - see emails 5.01.2022

--- a/tools/_shared/inc/helpers/gtfs_helpers.py
+++ b/tools/_shared/inc/helpers/gtfs_helpers.py
@@ -2,23 +2,34 @@ import os, sys
 import re
 import datetime
 
+from typing import Union
+
 from pathlib import Path
 
 def compute_formatted_date_from_gtfs_folder_path(folder_path: Path):
-    if isinstance(folder_path, str):
-        folder_path = Path(folder_path)
+    gtfs_filename_dt = compute_datetime_from_gtfs_resource_filename(folder_path)
+    if gtfs_filename_dt is None:
+        return None
+    
+    formatted_date = gtfs_filename_dt.strftime('%Y-%m-%d')
+    
+    return formatted_date
 
+def compute_datetime_from_gtfs_resource_filename(file_path: str) -> Union[datetime.datetime, None]:
+    if isinstance(file_path, str):
+        file_path = Path(file_path)
+        
     # gtfs_fp2021_2021-02-17_09-10
-    opentransport_matches = re.match("^.+?fp([0-9]{4})_([0-9]{4})-([0-9]{2})-([0-9]{2})_.*$", folder_path.name)
-
-    if opentransport_matches:
-        matched_year = opentransport_matches[2]
-        matched_month = opentransport_matches[3]
-        matched_day = opentransport_matches[4]
-        formatted_date = f"{matched_year}-{matched_month}-{matched_day}"
-        return formatted_date
-
-    return None
+    # GTFS_FP2024_2024-04-15_08-54.zip
+    dt_matches = re.match("^.+?[fpFP]([0-9]{4})_([0-9]{4})-([0-9]{2})-([0-9]{2})_([0-9]{2})-([0-9]{2}).*$", file_path.name)
+    
+    if dt_matches is None:
+        return None
+    
+    file_dt_s = f'{dt_matches[2]}-{dt_matches[3]}-{dt_matches[4]} {dt_matches[5]}:{dt_matches[6]}'
+    file_dt = datetime.datetime.strptime(file_dt_s, '%Y-%m-%d %H:%M')
+    
+    return file_dt
 
 def convert_datetime_to_day_minutes(datetime_s: str):
     # fix HRDF bug - see emails 5.01.2022

--- a/tools/_shared/inc/models/ckan_data.py
+++ b/tools/_shared/inc/models/ckan_data.py
@@ -1,0 +1,42 @@
+import os
+import sys
+
+from dataclasses import dataclass, asdict
+from typing import List, Dict, Optional
+
+@dataclass
+class CKAN_Resource:
+    identifier: str
+    mimetype: str
+    title: Dict[str, str]
+    url: str
+
+    def __init__(self, **kwargs):
+        self.identifier = kwargs['identifier']
+        self.mimetype = kwargs['mimetype']
+        self.title = kwargs['title']
+        self.url = kwargs['url']
+        
+@dataclass
+class CKAN_Result:
+    resources: List[CKAN_Resource]
+
+    def __init__(self, **kwargs):
+        self.resources = []
+        for resource_json in kwargs['resources']:
+            ckan_resource = CKAN_Resource(**resource_json)
+            self.resources.append(ckan_resource)
+        # loop resources
+
+@dataclass
+class CKAN_Data:
+    result: CKAN_Result
+
+    def __init__(self, **kwargs):
+        self.result = CKAN_Result(**kwargs['result'])
+
+    @staticmethod
+    def from_ckan_json(ckan_json):
+        ckan_data = CKAN_Data(**ckan_json)
+        return ckan_data
+    

--- a/tools/_shared/inc/models/ckan_data.py
+++ b/tools/_shared/inc/models/ckan_data.py
@@ -10,12 +10,14 @@ class CKAN_Resource:
     mimetype: str
     title: Dict[str, str]
     url: str
+    modified_s: str
 
     def __init__(self, **kwargs):
         self.identifier = kwargs['identifier']
         self.mimetype = kwargs['mimetype']
         self.title = kwargs['title']
         self.url = kwargs['url']
+        self.modified_s = kwargs['modified']
         
 @dataclass
 class CKAN_Result:

--- a/tools/_shared/inc/models/gtfs_rt.py
+++ b/tools/_shared/inc/models/gtfs_rt.py
@@ -1,0 +1,144 @@
+import os, sys
+
+import json
+
+from dataclasses import dataclass, asdict
+from typing import List, Optional
+
+@dataclass
+class Header:
+    gtfsRealtimeVersion: str
+    incrementality: str
+    timestamp: int
+  
+    @staticmethod
+    def from_gtfs_rt_json(json_data: dict):
+        header = Header(
+            gtfsRealtimeVersion=json_data['GtfsRealtimeVersion'],
+            incrementality=json_data['Incrementality'],
+            timestamp=json_data['Timestamp'],
+        )
+        
+        return header
+  
+@dataclass
+class StopTime:
+    delay: Optional[int] = None
+    time: Optional[int] = None
+    scheduleRelationship: Optional[str] = None
+  
+    @staticmethod
+    def from_gtfs_rt_json(json_data: dict):
+        stopTime = StopTime()
+        stopTime.delay = json_data.get('Delay', None)
+        stopTime.time = json_data.get('Time', None)
+        stopTime.scheduleRelationship = json_data.get('ScheduleRelationship', None)
+
+        return stopTime
+  
+@dataclass
+class StopTimeUpdate:
+    stopSequence: int
+    stopId: str
+    scheduleRelationship: str
+    arrival: Optional[StopTime] = None
+    departure: Optional[StopTime] = None
+    
+    @staticmethod
+    def from_gtfs_rt_json(json_data):
+        stopSequence = json_data['StopSequence']
+        stopId = json_data['StopId']
+        scheduleRelationship = json_data['ScheduleRelationship']
+
+        stopTimeUpdate = StopTimeUpdate(
+            stopSequence=stopSequence,
+            stopId=stopId,
+            scheduleRelationship=scheduleRelationship,
+        )
+    
+        if 'Arrival' in json_data:
+            stopTimeUpdate.arrival = StopTime.from_gtfs_rt_json(json_data['Arrival'])
+        if 'Departure' in json_data:
+            stopTimeUpdate.departure = StopTime.from_gtfs_rt_json(json_data['Departure'])
+    
+        return stopTimeUpdate
+  
+@dataclass
+class Trip:
+    tripId: str
+    routeId: str
+    startTime: str
+    startDate: str
+    scheduleRelationship: str
+    
+    @staticmethod
+    def from_gtfs_rt_json(json_data: dict):
+        trip = Trip(
+            tripId=json_data['TripId'],
+            routeId=json_data['RouteId'],
+            startTime=json_data['StartTime'],
+            startDate=json_data['StartDate'],
+            scheduleRelationship=json_data['ScheduleRelationship'],
+        )
+        
+        return trip
+  
+@dataclass
+class TripUpdate:
+    trip: Trip
+    stopTimeUpdate: List[StopTimeUpdate]
+    
+    @staticmethod
+    def from_gtfs_rt_json(json_data: dict):
+        trip = Trip.from_gtfs_rt_json(json_data['Trip'])
+        
+        stopTimeUpdates: List[StopTimeUpdate] = []
+        stop_times_update_gtfs_rt_json = json_data.get('StopTimeUpdate', [])
+        for stop_time_update_json_data in stop_times_update_gtfs_rt_json:
+            stop_time_update = StopTimeUpdate.from_gtfs_rt_json(stop_time_update_json_data)
+            stopTimeUpdates.append(stop_time_update)
+      
+        tripUpdate = TripUpdate(trip, stopTimeUpdates)
+    
+        return tripUpdate
+  
+@dataclass
+class Entity:
+    id: str
+    isDeleted: bool
+    tripUpdate: TripUpdate
+  
+    @staticmethod
+    def from_gtfs_rt_json(json_data):
+        entity = Entity(
+            id=json_data['Id'],
+            isDeleted=json_data['IsDeleted'],
+            tripUpdate=TripUpdate.from_gtfs_rt_json(json_data['TripUpdate'])
+        )
+    
+        return entity
+    
+    def as_json(self, light: bool):
+        entity_json = asdict(self)
+        if light:
+            entity_json['tripUpdate']['stopTimeUpdate'] = {}
+        
+        return entity_json        
+
+@dataclass
+class GTFS_RT_Response:
+    header: Header
+    entity: List[Entity]
+  
+    @staticmethod
+    def from_gtfs_rt_json(json_data: dict):
+        header = Header.from_gtfs_rt_json(json_data['Header'])
+    
+        entities: List[Entity] = []
+        for entity_json_data in json_data['Entity']:
+            entity = Entity.from_gtfs_rt_json(entity_json_data)
+            entities.append(entity)
+    
+        response = GTFS_RT_Response(header, entities)
+    
+        return response

--- a/tools/_shared/inc/models/gtfs_static_db.py
+++ b/tools/_shared/inc/models/gtfs_static_db.py
@@ -1,0 +1,28 @@
+import os, sys
+
+from dataclasses import dataclass
+from typing import List, Optional
+
+@dataclass
+class Route:
+    route_id: str
+    agency_id: str
+    route_short_name: str
+    route_long_name: str
+    route_type: int
+    route_desc: Optional[str] = None
+
+@dataclass
+class Trip:
+    trip_id: str
+    route_id: str
+    service_id: str
+    trip_headsign: Optional[str] = None
+    trip_short_name: Optional[str] = None
+    direction_id: Optional[str] = None
+    departure_day_minutes: Optional[int] = None
+    arrival_day_minutes: Optional[int] = None
+    departure_time: Optional[str] = None
+    arrival_time: Optional[str] = None
+    stop_times_s: Optional[str] = None
+    shape_id: Optional[str] = None

--- a/tools/_shared/inc/models/gtfs_static_db_catalog.py
+++ b/tools/_shared/inc/models/gtfs_static_db_catalog.py
@@ -1,0 +1,45 @@
+import os
+import sys
+
+from dataclasses import dataclass, asdict
+from typing import List, Dict, Optional
+
+@dataclass
+class GTFS_Static_Catalog_Item:
+    gtfs_datetime_s: str # %Y-%m-%d %H:%M
+    gtfs_day: str # %Y-%m-%d
+    gtfs_rt_switch_datetime_s: str # %Y-%m-%d %H:%M
+    table_stats: Dict[str, int]
+    db_relative_path: str
+    
+    def as_json(self):
+        data_json = asdict(self)
+        if self.db_relative_path is None:
+            data_json['db_relative_path'] = None
+
+        return data_json
+
+@dataclass
+class GTFS_Static_Catalog_Report:
+    metadata: str
+    items: List[GTFS_Static_Catalog_Item]
+    
+    @staticmethod
+    def from_json(report_json):
+        report = GTFS_Static_Catalog_Report(**report_json)
+        report.items = []
+        for report_item_json in report_json['items']:
+            report_item = GTFS_Static_Catalog_Item(**report_item_json)
+            report.items.append(report_item)
+
+        return report
+    
+    def as_json(self):
+        data_json = asdict(self)
+        
+        data_json['items'] = []
+        for item in self.items:
+            item_json = item.as_json()
+            data_json['items'].append(item_json)
+        
+        return data_json

--- a/tools/ckan-utils/inc/ckan_controller.py
+++ b/tools/ckan-utils/inc/ckan_controller.py
@@ -33,7 +33,7 @@ class CKAN_Controller:
             print('')
             log_message(f'... resource already downloaded at path {ds_zip_path}')
         else:
-            ds_url = ds_resource['url']
+            ds_url = ds_resource.url
             download_resource(ds_url, ds_zip_path)
 
         if os.path.isdir(ds_folder_path):

--- a/tools/ckan-utils/inc/ckan_controller.py
+++ b/tools/ckan-utils/inc/ckan_controller.py
@@ -57,9 +57,15 @@ class CKAN_Controller:
 
             if resource_title[0:-4] == filter_resource_title[0:-4]:
                 return ds_resource
-
+            
+        row_delimiter_s = '='*70
+        
+        print()
+        print(row_delimiter_s)
         print(f'ERROR - cant find resource with title {filter_resource_title}')
-        print(f'Available resources:')
+        print(row_delimiter_s)
+        print(f'Available resources:                        - Last modified')
+        print(row_delimiter_s)
 
         for ds_resource in ckan_data.result.resources:
             resource_title: str = ds_resource.title['en'].strip().lower()
@@ -68,8 +74,10 @@ class CKAN_Controller:
             last_modified_hh_mm = ds_resource.modified_s[11:16]
             last_modified_s = f'{last_modified_day} {last_modified_hh_mm}'
 
-            print(f'-- {resource_title} - {last_modified_s}')
-        sys.exit()
+            print(f'-- {resource_title.ljust(40)} - {last_modified_s}')
+        # loop resources
+        
+        sys.exit(1)
 
     def _fetch_ckan_data(self, package_key):
         package_data_json_path = f"{self.app_config['package_cache']['local_path']}"

--- a/tools/ckan-utils/inc/ckan_controller.py
+++ b/tools/ckan-utils/inc/ckan_controller.py
@@ -21,7 +21,7 @@ class CKAN_Controller:
         log_message(f'  RESOURCE_TITLE  : {resource_title}')
 
         ds_resource = self._fetch_package_resource(package_key, resource_title)
-        ds_filename = ds_resource.title['en'].lower()
+        ds_filename = ds_resource.title['en']
         ds_folder = ds_filename[0:-4]
 
         package_data = self.app_config['map_packages'][package_key]

--- a/tools/ckan-utils/inc/ckan_controller.py
+++ b/tools/ckan-utils/inc/ckan_controller.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from .shared.inc.helpers.json_helpers import export_json_to_file, load_json_from_file
 from .shared.inc.helpers.log_helpers import log_message
 
+from .shared.inc.models.ckan_data import CKAN_Data
 class CKAN_Controller:
     def __init__(self, app_config):
         self.app_config = app_config
@@ -20,7 +21,7 @@ class CKAN_Controller:
         log_message(f'  RESOURCE_TITLE  : {resource_title}')
 
         ds_resource = self._fetch_package_resource(package_key, resource_title)
-        ds_filename = ds_resource['title']['en'].lower()
+        ds_filename = ds_resource.title['en'].lower()
         ds_folder = ds_filename[0:-4]
 
         package_data = self.app_config['map_packages'][package_key]
@@ -44,15 +45,15 @@ class CKAN_Controller:
         log_message(f'CKAN - DONE')
 
     def _fetch_package_resource(self, package_key: str, filter_resource_title):
-        package_data_json = self._fetch_package_json(package_key)
-
+        ckan_data = self._fetch_ckan_data(package_key)
+        
         if filter_resource_title is None:
-            return package_data_json['result']['resources'][0]
-
+            return ckan_data.result.resources[0]
+        
         filter_resource_title = filter_resource_title.strip().lower()
         
-        for ds_resource in package_data_json['result']['resources']:
-            resource_title = ds_resource['title']['en'].strip().lower()
+        for ds_resource in ckan_data.result.resources:
+            resource_title = ds_resource.title['en'].strip().lower()
 
             if resource_title[0:-4] == filter_resource_title[0:-4]:
                 return ds_resource
@@ -60,17 +61,17 @@ class CKAN_Controller:
         print(f'ERROR - cant find resource with title {filter_resource_title}')
         print(f'Available resources:')
 
-        for ds_resource in package_data_json['result']['resources']:
-            resource_title = ds_resource['title']['en'].strip().lower()
+        for ds_resource in ckan_data.result.resources:
+            resource_title: str = ds_resource.title['en'].strip().lower()
             
-            last_modified_day = ds_resource['last_modified'][0:10]
-            last_modified_hh_mm = ds_resource['last_modified'][11:16]
+            last_modified_day = ds_resource.modified_s[0:10]
+            last_modified_hh_mm = ds_resource.modified_s[11:16]
             last_modified_s = f'{last_modified_day} {last_modified_hh_mm}'
 
             print(f'-- {resource_title} - {last_modified_s}')
         sys.exit()
 
-    def _fetch_package_json(self, package_key):
+    def _fetch_ckan_data(self, package_key):
         package_data_json_path = f"{self.app_config['package_cache']['local_path']}"
         package_data_json_path = package_data_json_path.replace('[PACKAGE_KEY]', package_key)
 
@@ -82,7 +83,8 @@ class CKAN_Controller:
             if cache_age < package_data_json_ttl:
                 log_message(f'... load package JSON from {package_data_json_path}')
                 package_data_json = load_json_from_file(package_data_json_path)
-                return package_data_json
+                ckan_data = CKAN_Data.from_ckan_json(package_data_json)
+                return ckan_data
 
         package_data = self.app_config['map_packages'][package_key]
         package_id = package_data['package_id']
@@ -96,8 +98,10 @@ class CKAN_Controller:
 
         package_data_json = fetch_latest_ckan_json(ckan_api_url, ckan_api_authorization)
         export_json_to_file(package_data_json, package_data_json_path, pretty_print=True)
+        
+        ckan_data = CKAN_Data.from_ckan_json(package_data_json)
 
-        return package_data_json
+        return ckan_data
 
 def fetch_latest_ckan_json(ckan_api_url, ckan_api_authorization):
     request_headers = {

--- a/tools/gtfs-hrdf-compare/inc/gtfs_hrdf_compare.py
+++ b/tools/gtfs-hrdf-compare/inc/gtfs_hrdf_compare.py
@@ -11,7 +11,6 @@ from .shared.inc.models.gtfs_static.calendar import Calendar as GTFS_Calendar
 from .shared.inc.models.gtfs_static.trip import Trip as GTFS_Trip
 from .shared.inc.models.hrdf.trip_variant import Trip_Variant as HRDF_Trip_Variant
 
-from .shared.inc.helpers.gtfs_helpers import compute_formatted_date_from_gtfs_folder_path
 from .shared.inc.helpers.hrdf_helpers import compute_calendar_info
 from .shared.inc.helpers.file_helpers import compute_file_rows_no
 from .shared.inc.helpers.csv_updater import CSV_Updater

--- a/tools/gtfs-prev-compare/gtfs_prev_compare_cli.py
+++ b/tools/gtfs-prev-compare/gtfs_prev_compare_cli.py
@@ -1,9 +1,6 @@
 import argparse, os, sys
 from pathlib import Path
 
-# from inc.db_importer import GTFS_DB_Importer
-# from inc.shared.inc.helpers.gtfs_helpers import compute_formatted_date_from_gtfs_folder_path
-
 from inc.gtfs_reader import GTFS_Reader
 
 def main():

--- a/tools/gtfs-prev-compare/inc/gtfs_reader.py
+++ b/tools/gtfs-prev-compare/inc/gtfs_reader.py
@@ -3,15 +3,15 @@ import csv
 
 from pathlib import Path
 
-from .shared.inc.helpers.gtfs_helpers import compute_formatted_date_from_gtfs_folder_path
+from .shared.inc.helpers.gtfs_helpers import compute_gtfs_day_from_resource_path
 from .shared.inc.helpers.file_helpers import compute_file_rows_no
 
 class GTFS_Reader:
     def compute_gtfs_stats(gtfs_a_path: Path, gtfs_b_path: Path):
         gtfs_table_names = ['agency', 'calendar_dates', 'calendar', 'routes', 'stop_times', 'stops', 'transfers', 'trips']
 
-        gtfs_a_date_f = compute_formatted_date_from_gtfs_folder_path(gtfs_a_path)
-        gtfs_b_date_f = compute_formatted_date_from_gtfs_folder_path(gtfs_b_path)
+        gtfs_a_date_f = compute_gtfs_day_from_resource_path(gtfs_a_path)
+        gtfs_b_date_f = compute_gtfs_day_from_resource_path(gtfs_b_path)
 
         print(f'--------------------------------------------------------------------------------')
         print(f'| table              | GTFS {gtfs_a_date_f} | GTFS {gtfs_b_date_f} |  DELTA |')

--- a/tools/gtfs-rt-static-compare/cli_aggregate_monthly_reports_json.py
+++ b/tools/gtfs-rt-static-compare/cli_aggregate_monthly_reports_json.py
@@ -1,0 +1,76 @@
+import os, sys
+
+import re
+import argparse
+from datetime import datetime
+
+from pathlib import Path
+
+from typing import List, Dict
+
+from compare_gtfs_rt_static.helpers.config_helpers import load_yaml_config
+from compare_gtfs_rt_static.helpers.json_helpers import load_json_from_file, export_json_to_file
+from compare_gtfs_rt_static.helpers.log_helpers import log_message
+
+from compare_gtfs_rt_static.models.gtfs_rt_static_report import GTFS_RT_Static_Report, GTFS_RT_Static_Report_Metadata
+
+def main():
+    app_path = Path(os.path.realpath(__file__)).parent
+    config_path = f'{app_path}/config/config.yml'
+    
+    app_config = load_yaml_config(config_path, app_path)
+    report_template_path: str = app_config['resource_paths']['gtfs_rt_static_report']
+    report_root_path = Path(report_template_path.split('[YEAR]/[MONTH]/[DAY]')[0])
+    
+    report_now = datetime.now()
+    report_ym = report_now.strftime('%Y-%m')
+    
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--month', '--month', default=report_ym)
+    args = parser.parse_args()
+    
+    report_ym = args.month
+    
+    log_message(f'START aggregate reports for {report_ym}')
+    
+    report_month_parts = report_ym.split('-')
+    report_year = report_month_parts[0]
+    report_month = report_month_parts[1]
+    
+    report_month_part = Path(f'{report_root_path}/{report_year}/{report_month}')
+    report_file_paths: List[Path] = []
+    for gtfs_rt_report_path in report_month_part.rglob('*.json'):
+        report_file_paths.append(gtfs_rt_report_path)
+    report_file_paths.sort()
+    
+    map_report_days: Dict[str, Dict[str, List[any]]] = {}
+    for gtfs_rt_report_path in report_file_paths:
+        gtfs_rt_report_json = load_json_from_file(gtfs_rt_report_path)
+        gtfs_rt_report = GTFS_RT_Static_Report.from_json(gtfs_rt_report_json)
+        
+        file_matches = re.match(r"gtfs_rt_static_report-([0-9]{4})-([0-9]{2})-([0-9]{2})-([0-9]{2})([0-9]{2})", gtfs_rt_report_path.name)
+        if file_matches is None:
+            print('ERROR - unknown file pattern')
+            print(gtfs_rt_report_path)
+            sys.exit(1)
+            
+        report_day = file_matches[3]
+        report_hhmm = file_matches[4] + file_matches[5]
+        
+        if report_day not in map_report_days:
+            map_report_days[report_day] = {}
+            
+        map_report_days[report_day][report_hhmm] = gtfs_rt_report.metadata.as_json()
+    # report_file_paths
+    
+    report_path: str = app_config['resource_paths']['gtfs_rt_static_mo_json']
+    report_path = report_path.replace('[YEAR]', report_year)
+    report_path = report_path.replace('[MONTH]', report_month)
+    
+    export_json_to_file(map_report_days, json_path=report_path, pretty_print=True)
+    log_message(f'... saved {len(report_file_paths)} reports to {report_path}')
+    
+    log_message(f'... DONE')
+
+if __name__ == "__main__":
+    main()

--- a/tools/gtfs-rt-static-compare/cli_aggregate_monthly_reports_json.py
+++ b/tools/gtfs-rt-static-compare/cli_aggregate_monthly_reports_json.py
@@ -12,7 +12,7 @@ from compare_gtfs_rt_static.helpers.config_helpers import load_yaml_config
 from compare_gtfs_rt_static.helpers.json_helpers import load_json_from_file, export_json_to_file
 from compare_gtfs_rt_static.helpers.log_helpers import log_message
 
-from compare_gtfs_rt_static.models.gtfs_rt_static_report import GTFS_RT_Static_Report, GTFS_RT_Static_Report_Metadata
+from compare_gtfs_rt_static.models.gtfs_rt_static_report import GTFS_RT_Static_Report, GTFS_RT_Static_Monthly_Report
 
 def main():
     app_path = Path(os.path.realpath(__file__)).parent
@@ -43,7 +43,7 @@ def main():
         report_file_paths.append(gtfs_rt_report_path)
     report_file_paths.sort()
     
-    map_report_days: Dict[str, Dict[str, List[any]]] = {}
+    map_report_days: Dict[str, Dict[str, GTFS_RT_Static_Report]] = {}
     for gtfs_rt_report_path in report_file_paths:
         gtfs_rt_report_json = load_json_from_file(gtfs_rt_report_path)
         gtfs_rt_report = GTFS_RT_Static_Report.from_json(gtfs_rt_report_json)
@@ -63,11 +63,19 @@ def main():
         map_report_days[report_day][report_hhmm] = gtfs_rt_report.metadata.as_json()
     # report_file_paths
     
+    report_now_f = report_now.strftime('%Y-%m-%d %H:%M:%S')
+    report_comments = f'generated {report_now_f} with {Path(__file__).name}'
+    
+    gtfs_rt_static_monthly_report = GTFS_RT_Static_Monthly_Report(
+        comments=report_comments,
+        report_days=map_report_days
+    )
+    
     report_path: str = app_config['resource_paths']['gtfs_rt_static_mo_json']
     report_path = report_path.replace('[YEAR]', report_year)
     report_path = report_path.replace('[MONTH]', report_month)
     
-    export_json_to_file(map_report_days, json_path=report_path, pretty_print=True)
+    export_json_to_file(gtfs_rt_static_monthly_report.as_json(), json_path=report_path, pretty_print=True)
     log_message(f'... saved {len(report_file_paths)} reports to {report_path}')
     
     log_message(f'... DONE')

--- a/tools/gtfs-rt-static-compare/cli_compare_latest.py
+++ b/tools/gtfs-rt-static-compare/cli_compare_latest.py
@@ -1,0 +1,13 @@
+import os, sys
+
+from pathlib import Path
+
+from compare_gtfs_rt_static.gtfs_controller import GTFS_Controller
+
+def main():
+    app_path = Path(os.path.realpath(__file__)).parent
+    gtfs_controller = GTFS_Controller(app_path)
+    gtfs_controller.compare_latest_gtfs_rt_static()
+
+if __name__ == "__main__":
+    main()

--- a/tools/gtfs-rt-static-compare/cli_compare_latest.sh
+++ b/tools/gtfs-rt-static-compare/cli_compare_latest.sh
@@ -1,0 +1,4 @@
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+
+python3 $DIR/cli_compare_latest.py
+python3 $DIR/cli_aggregate_monthly_reports_json.py

--- a/tools/gtfs-rt-static-compare/compare_gtfs_rt_static/fetch.py
+++ b/tools/gtfs-rt-static-compare/compare_gtfs_rt_static/fetch.py
@@ -1,0 +1,56 @@
+import os, sys
+
+from datetime import datetime
+from pathlib import Path
+
+import requests
+
+from .helpers.json_helpers import load_json_from_file, export_json_to_file
+from .models.gtfs_rt import GTFS_RT_Response
+
+def fetch_latest(app_config: dict, gtfs_rt_snapshot_path: Path):
+    if not os.path.isdir(gtfs_rt_snapshot_path.parent):
+        os.makedirs(gtfs_rt_snapshot_path.parent)
+        
+    gtfs_rt_response_json = _fetch_latest_gtfs_rt_resource(app_config, gtfs_rt_snapshot_path)
+    gtfs_rt_response = GTFS_RT_Response.from_gtfs_rt_json(gtfs_rt_response_json)
+    
+    return gtfs_rt_response
+
+def compute_resource_snapshot_path(resource_path: str, fetch_dt: datetime):
+    dt_year = fetch_dt.strftime('%Y')
+    dt_month = fetch_dt.strftime('%m')
+    dt_day = fetch_dt.strftime('%d')
+    dt_hhmm = fetch_dt.strftime('%H%M')
+    
+    resource_path = resource_path.replace('[YEAR]', dt_year)
+    resource_path = resource_path.replace('[MONTH]', dt_month)
+    resource_path = resource_path.replace('[DAY]', dt_day)
+    resource_path = resource_path.replace('[HHMM]', dt_hhmm)
+    
+    return Path(resource_path)
+
+def _fetch_latest_gtfs_rt_resource(app_config: dict, resource_path: Path):
+    if os.path.isfile(resource_path):
+        gtfs_rt_json = load_json_from_file(resource_path)
+        return gtfs_rt_json
+    
+    url = app_config['opentransportdata']['gtfs_rt_url']
+    api_key = app_config['opentransportdata']['key']
+    
+    http_headers = {
+        'Authorization': f'Bearer {api_key}'
+    }
+    
+    response = requests.get(url, headers=http_headers, timeout=10)
+    if response.status_code != 200:
+        print(f'ERROR - broken response fom {url}')
+        print(response.text)
+        sys.exit(1)
+    
+    # save it formatted
+    response_json = response.json()
+    export_json_to_file(response_json, resource_path, pretty_print=True)
+    gtfs_rt_json = load_json_from_file(resource_path)
+    
+    return gtfs_rt_json

--- a/tools/gtfs-rt-static-compare/compare_gtfs_rt_static/gtfs_controller.py
+++ b/tools/gtfs-rt-static-compare/compare_gtfs_rt_static/gtfs_controller.py
@@ -1,0 +1,294 @@
+import os, sys
+
+from pathlib import Path
+
+from typing import Dict, Optional
+
+from datetime import datetime, timedelta
+
+from .helpers.config_helpers import load_yaml_config
+from .helpers.gtfs_helpers import compute_gtfs_db_filename
+from .helpers.json_helpers import load_json_from_file, export_json_to_file
+from .helpers.db_engine import SQLiteDBEngine
+from .helpers.log_helpers import log_message
+
+from .models.gtfs_rt import GTFS_RT_Response
+from .models.gtfs_rt_static_report import GTFS_RT_Static_Report, GTFS_RT_Static_Report_Metadata
+
+from .models.gtfs_static_db import Route as RouteDB
+from .models.gtfs_static_db import Trip as TripDB
+
+from .fetch import fetch_latest, compute_resource_snapshot_path
+
+class GTFS_DB:
+    _db: SQLiteDBEngine
+    map_routes: Dict[str, RouteDB]
+    map_trips: Dict[str, TripDB]
+    _gtfs_db_table_cache_template: Optional[str]
+    
+    def __init__(self, db_path: Path, resources_path_config: Optional[Dict[str, str]]):
+        self._db = SQLiteDBEngine(db_path)
+        
+        self.map_routes = {}
+        self.map_routes = {}
+        
+        if resources_path_config is not None:
+            self._gtfs_db_table_cache_template = resources_path_config.get('cache_gtfs_db_table', None)
+            
+    def init_lookups(self):
+        gtfs_routes_db = self._load_gtfs_table('routes', map_by_field='route_id')
+        self.map_routes = {}
+        for route_id, route_db_json in gtfs_routes_db.items():
+            self.map_routes[route_id] = RouteDB(**route_db_json)        
+        
+        gtfs_trips_db = self._load_gtfs_table('trips', map_by_field='trip_id')
+        self.map_trips: dict[str, TripDB] = {}
+        for trip_id, trip_db_json in gtfs_trips_db.items():
+            self.map_trips[trip_id] = TripDB(**trip_db_json)
+        
+    def _load_gtfs_table(self, table_name: str, map_by_field: str = None):
+        res_cache_path = None
+        if self._gtfs_db_table_cache_template is not None:
+            res_cache_path_s: str = f'{self._gtfs_db_table_cache_template}'
+            res_cache_path_s = res_cache_path_s.replace('[GTFS_FILENAME]', f'{self._db.db_path.name}')
+            res_cache_path_s = res_cache_path_s.replace('[TABLE_NAME]', table_name)
+            res_cache_path = Path(res_cache_path_s)
+        
+            if os.path.isfile(res_cache_path):
+                res_json = load_json_from_file(res_cache_path)
+                return res_json
+        
+        sql = None
+        if table_name == 'trips':
+            sql = 'SELECT trip_id, route_id, service_id FROM trips'
+        if sql is None:
+            sql = f'SELECT * FROM {table_name}'
+            
+        res_json = self._db.query(sql, map_by_field=map_by_field)
+        
+        if res_cache_path is not None:
+            export_json_to_file(res_json, res_cache_path, pretty_print=True)
+        
+        return res_json
+        
+class GTFS_Controller:
+    def __init__(self, app_path: Path):
+        config_path = f'{app_path}/config/config.yml'
+        self.app_config = load_yaml_config(config_path, app_path=app_path)
+        
+    def compare_latest_gtfs_rt_static(self):
+        self._compare_compare_latest_gtfs_rt_static()
+        
+    def load_gtfs_db(self, gtfs_db_dt: datetime):
+        return self._load_gtfs_db(gtfs_db_dt)
+    
+    def compare_gtfs_rt_from_file(self, gtfs_static_db_dt: datetime, gtfs_rt_file_dt: datetime, gtfs_rt_path: Path, gtfs_db: GTFS_DB):
+        self._compare_gtfs_rt_from_file(gtfs_static_db_dt, gtfs_rt_file_dt, gtfs_rt_path, gtfs_db)
+        
+    def compute_gtfs_db_dt(self, dt: datetime):
+        return self._compute_gtfs_db_dt(dt)
+        
+    # PRIVATE
+    def _compare_compare_latest_gtfs_rt_static(self):
+        log_message(f'START COMPARE GTFS -RT GTFS STATIC')
+        
+        fetch_dt = datetime.now()
+        
+        log_message(f'... START fetch GTFS-RT')
+        log_message(f'... TS REQUEST    : {fetch_dt}')
+        
+        resource_path = self.app_config['resource_paths']['gtfs_rt_snapshot']
+        gtfs_rt_snapshot_path = compute_resource_snapshot_path(resource_path, fetch_dt)
+        gtfs_rt_response = fetch_latest(self.app_config, gtfs_rt_snapshot_path)
+        
+        gtfs_rt_dt = datetime.fromtimestamp(gtfs_rt_response.header.timestamp)
+        
+        gtfs_db_dt = self._compute_gtfs_db_dt(gtfs_rt_dt)
+        
+        # wednesdays are special, the DB might not be ready yet
+        wed_week_idx = 2
+        if gtfs_rt_dt.weekday() == wed_week_idx:
+            gtfs_db_dt = self._rewind_gtfs_db_dt_if_needed(gtfs_db_dt)
+            
+        gtfs_db = self._load_gtfs_db(gtfs_db_dt)
+        if gtfs_db is None:
+            gtfs_db_day = gtfs_db_dt.strftime('%Y-%m-%d')
+            print(f'ERROR: no DB found for {gtfs_db_day}')
+            return
+        
+        self._compare_file_gtfs_rt_static(
+            fetch_dt, gtfs_db_dt, 
+            gtfs_rt_snapshot_path, gtfs_rt_response, gtfs_db
+        )
+        
+    def _rewind_gtfs_db_dt_if_needed(self, gtfs_db_dt: datetime):
+        gtfs_db_day = gtfs_db_dt.strftime('%Y-%m-%d')
+        gtfs_db_filename = compute_gtfs_db_filename(gtfs_db_day)
+        gtfs_db_path: str = self.app_config['resource_paths']['gtfs_db']
+        gtfs_db_path = gtfs_db_path.replace('[GTFS_FILENAME]', gtfs_db_filename)
+        
+        if not os.path.isfile(gtfs_db_path):
+            gtfs_db_dt = gtfs_db_dt - timedelta(days=7)
+            
+        return gtfs_db_dt
+        
+    def _load_gtfs_db(self, gtfs_db_dt: datetime):
+        log_message(f'START GTFS lookups')
+        
+        gtfs_day = gtfs_db_dt.strftime('%Y-%m-%d')
+        gtfs_db_filename = compute_gtfs_db_filename(gtfs_day)
+        log_message(f'... loading {gtfs_db_filename}')
+        gtfs_db_path: str = self.app_config['resource_paths']['gtfs_db']
+        gtfs_db_path = gtfs_db_path.replace('[GTFS_FILENAME]', gtfs_db_filename)
+        
+        if not os.path.isfile(gtfs_db_path):
+            return None
+        
+        gtfs_db = GTFS_DB(gtfs_db_path, self.app_config['resource_paths'])
+        gtfs_db.init_lookups()
+        
+        log_message(f'... DONE GTFS lookups')
+        
+        return gtfs_db
+    
+    def _compare_gtfs_rt_from_file(self, gtfs_static_db_dt: datetime, gtfs_rt_file_dt: datetime, gtfs_rt_path: Path, gtfs_db: GTFS_DB):
+        log_message(f'... JSON path: {gtfs_rt_path}')
+        
+        gtfs_rt_json = load_json_from_file(gtfs_rt_path)
+        gtfs_rt_response = GTFS_RT_Response.from_gtfs_rt_json(gtfs_rt_json)
+        
+        self._compare_file_gtfs_rt_static(
+            gtfs_rt_file_dt, gtfs_static_db_dt, 
+            gtfs_rt_path, gtfs_rt_response, gtfs_db
+        )
+        
+    def _compare_file_gtfs_rt_static(self, report_dt: datetime, gtfs_db_dt: datetime, gtfs_rt_path: Path, gtfs_rt_response: GTFS_RT_Response, gtfs_db: GTFS_DB):
+        gtfs_rt_dt = datetime.fromtimestamp(gtfs_rt_response.header.timestamp)
+        log_message(f'... RESPONSE')
+        log_message(f'... rows: {len(gtfs_rt_response.entity)}')
+        log_message(f'... TS RESPONSE   : {gtfs_rt_dt}')
+        
+        gtfs_static_day = gtfs_db_dt.strftime('%Y-%m-%d')
+        gtfs_rt_age = round(gtfs_rt_dt.timestamp() - report_dt.timestamp())
+        
+        report_metdata = GTFS_RT_Static_Report_Metadata(
+            report_dt=report_dt,
+            gtfs_db_filename=compute_gtfs_db_filename(gtfs_static_day),
+            gtfs_rt_filename=gtfs_rt_path.name,
+            gtfs_rt_ts=round(gtfs_rt_dt.timestamp()),
+            gtfs_rt_dt=gtfs_rt_dt,
+            gtfs_rt_age=gtfs_rt_age,
+    
+            total_rows_no=0,
+            tripOK_routeOK_no=0,
+            tripOK_routeNOK_no=0,
+            tripNOK_routeOK_no=0,
+            tripNOK_routeNOK_no=0,
+        )
+        
+        report_stats = GTFS_RT_Static_Report.init_with_metadata(report_metdata)
+        
+        for entity in gtfs_rt_response.entity:
+            report_stats.metadata.total_rows_no += 1
+            
+            trip_id = entity.tripUpdate.trip.tripId
+            route_id = entity.tripUpdate.trip.routeId
+            
+            trip_OK = trip_id in gtfs_db.map_trips
+            route_OK = route_id in gtfs_db.map_routes
+            
+            if trip_OK and route_OK:
+                report_stats.metadata.tripOK_routeOK_no += 1
+                
+            if trip_OK and not route_OK:
+                report_stats.tripOK_routeNOK.append(entity.id)
+                report_stats.metadata.tripOK_routeNOK_no += 1
+                
+            if not trip_OK and route_OK:
+                report_stats.tripNOK_routeOK.append(entity.id)
+                report_stats.metadata.tripNOK_routeOK_no += 1
+                
+            if not trip_OK and not route_OK:
+                report_stats.tripNOK_routeNOK.append(entity.id)
+                report_stats.metadata.tripNOK_routeNOK_no += 1
+        # loop entity
+
+        print(f'age                 : {gtfs_rt_age}')
+        if abs(gtfs_rt_age) > 60:
+            print(f'                    : ERROR, TOO OLD')
+            print(f'                    : ' + gtfs_rt_dt.strftime('%Y-%m-%d %H:%M:%S'))
+            print(f'                    : ' + report_dt.strftime('%Y-%m-%d %H:%M:%S'))
+            print()
+        print(f'rows                : {report_stats.metadata.total_rows_no}')
+        print(f'OK                  : {report_stats.metadata.tripOK_routeOK_no}')
+        print(f'tripOK  - routeNOT  : {len(report_stats.tripOK_routeNOK)}')
+        print(f'tripNOT - routeOK   : {len(report_stats.tripNOK_routeOK)}')
+        print(f'tripNOT - routeNOT  : {len(report_stats.tripNOK_routeNOK)}')
+        print()
+        
+        report_path = self.app_config['resource_paths']['gtfs_rt_static_report']
+        report_path = compute_resource_snapshot_path(report_path, report_dt)
+        report_json = report_stats.as_json()
+        export_json_to_file(report_json, report_path, pretty_print=True)
+        log_message(f'... saved to {report_path}')
+        
+        log_message('... DONE')
+        
+    def _compute_gtfs_db_dt(self, dt: datetime):
+        # GTFS static is published Wednesdays
+        wed_week_idx = 2
+        
+        days_since_last_wed = (dt.weekday() - wed_week_idx) % 7
+        
+        # ... around 5AM
+        if days_since_last_wed == 0:
+            dt_hhmm = dt.strftime('%H%M')
+            # at 6AM runs the cronjob for the new DB
+            if dt_hhmm < "0700":
+                days_since_last_wed = 7
+                
+        last_wed_dt = dt - timedelta(days=days_since_last_wed)
+        
+        return last_wed_dt
+        
+    def _compute_gtfs_db_filename_from_day(self, dt: datetime):
+        last_wed_dt = self._compute_gtfs_db_dt(dt)
+        
+        last_wed_day = last_wed_dt.strftime("%Y-%m-%d")      
+        gtfs_db_filename = compute_gtfs_db_filename(last_wed_day)
+        
+        return gtfs_db_filename
+    
+    def _load_gtfs_table(self, gtfs_db: SQLiteDBEngine, table_name: str, map_by_field: str = None):
+        res_cache_path_s: str = self.app_config['resource_paths']['cache_gtfs_db_table']
+        res_cache_path_s = res_cache_path_s.replace('[GTFS_FILENAME]', f'{gtfs_db.db_path.name}')
+        res_cache_path_s = res_cache_path_s.replace('[TABLE_NAME]', table_name)
+        res_cache_path = Path(res_cache_path_s)
+        
+        if os.path.isfile(res_cache_path):
+            res_json = load_json_from_file(res_cache_path)
+            return res_json
+        
+        sql = None
+        if table_name == 'trips':
+            sql = 'SELECT trip_id, route_id, service_id FROM trips'
+        if sql is None:
+            sql = f'SELECT * FROM {table_name}'
+            
+        res_json = gtfs_db.query(sql, map_by_field=map_by_field)
+        
+        export_json_to_file(res_json, res_cache_path, pretty_print=True)
+        
+        return res_json
+        
+    def _init_gtfs_db(self, gtfs_db_filename: str):
+        gtfs_db_path: str = self.app_config['resource_paths']['gtfs_db']
+        gtfs_db_path = gtfs_db_path.replace('[GTFS_FILENAME]', gtfs_db_filename)
+        
+        if not os.path.isfile(gtfs_db_path):
+            return None
+        
+        gtfs_db = GTFS_DB(gtfs_db_path, self.app_config['resource_paths'])
+        gtfs_db.init_lookups()
+        
+        return gtfs_db

--- a/tools/gtfs-rt-static-compare/compare_gtfs_rt_static/gtfs_controller.py
+++ b/tools/gtfs-rt-static-compare/compare_gtfs_rt_static/gtfs_controller.py
@@ -9,69 +9,14 @@ from datetime import datetime, timedelta
 from .helpers.config_helpers import load_yaml_config
 from .helpers.gtfs_helpers import compute_gtfs_db_filename
 from .helpers.json_helpers import load_json_from_file, export_json_to_file
-from .helpers.db_engine import SQLiteDBEngine
 from .helpers.log_helpers import log_message
 
 from .models.gtfs_rt import GTFS_RT_Response
 from .models.gtfs_rt_static_report import GTFS_RT_Static_Report, GTFS_RT_Static_Report_Metadata
 
-from .models.gtfs_static_db import Route as RouteDB
-from .models.gtfs_static_db import Trip as TripDB
+from .gtfs_db import GTFS_DB
 
 from .fetch import fetch_latest, compute_resource_snapshot_path
-
-class GTFS_DB:
-    _db: SQLiteDBEngine
-    map_routes: Dict[str, RouteDB]
-    map_trips: Dict[str, TripDB]
-    _gtfs_db_table_cache_template: Optional[str]
-    
-    def __init__(self, db_path: Path, resources_path_config: Optional[Dict[str, str]]):
-        self._db = SQLiteDBEngine(db_path)
-        
-        self.map_routes = {}
-        self.map_routes = {}
-        
-        if resources_path_config is not None:
-            self._gtfs_db_table_cache_template = resources_path_config.get('cache_gtfs_db_table', None)
-            
-    def init_lookups(self):
-        gtfs_routes_db = self._load_gtfs_table('routes', map_by_field='route_id')
-        self.map_routes = {}
-        for route_id, route_db_json in gtfs_routes_db.items():
-            self.map_routes[route_id] = RouteDB(**route_db_json)        
-        
-        gtfs_trips_db = self._load_gtfs_table('trips', map_by_field='trip_id')
-        self.map_trips: dict[str, TripDB] = {}
-        for trip_id, trip_db_json in gtfs_trips_db.items():
-            self.map_trips[trip_id] = TripDB(**trip_db_json)
-            # Dont use Trip because is slower init
-            # self.map_trips[trip_id] = Trip.init_from_db_row(trip_db_json, gtfs_calendar_db, gtfs_agency_db, gtfs_routes_db, gtfs_stops_db)
-        
-    def _load_gtfs_table(self, table_name: str, map_by_field: str = None):
-        res_cache_path = None
-        if self._gtfs_db_table_cache_template is not None:
-            res_cache_path_s: str = f'{self._gtfs_db_table_cache_template}'
-            res_cache_path_s = res_cache_path_s.replace('[GTFS_FILENAME]', f'{self._db.db_path.name}')
-            res_cache_path_s = res_cache_path_s.replace('[TABLE_NAME]', table_name)
-            res_cache_path = Path(res_cache_path_s)
-        
-            if os.path.isfile(res_cache_path):
-                res_json = load_json_from_file(res_cache_path)
-                return res_json
-        
-        sql = None
-        if table_name == 'trips':
-            sql = 'SELECT trip_id, route_id, service_id FROM trips'
-        if sql is None:
-            sql = f'SELECT * FROM {table_name}'
-            
-        res_json = self._db.query(sql, map_by_field=map_by_field)
-        
-        if res_cache_path is not None:
-            export_json_to_file(res_json, res_cache_path, pretty_print=True)
-        
-        return res_json
 
 class GTFS_Controller:
     def __init__(self, app_path: Path):

--- a/tools/gtfs-rt-static-compare/compare_gtfs_rt_static/gtfs_controller.py
+++ b/tools/gtfs-rt-static-compare/compare_gtfs_rt_static/gtfs_controller.py
@@ -2,15 +2,16 @@ import os, sys
 
 from pathlib import Path
 
-from typing import Dict, Optional
+from typing import Union, List
 
-from datetime import datetime, timedelta
+from datetime import datetime
 
 from .helpers.config_helpers import load_yaml_config
 from .helpers.gtfs_helpers import compute_gtfs_db_filename
 from .helpers.json_helpers import load_json_from_file, export_json_to_file
 from .helpers.log_helpers import log_message
 
+from .models.gtfs_static_db_catalog import GTFS_Static_Catalog_Report, GTFS_Static_Catalog_Item
 from .models.gtfs_rt import GTFS_RT_Response
 from .models.gtfs_rt_static_report import GTFS_RT_Static_Report, GTFS_RT_Static_Report_Metadata
 
@@ -23,17 +24,21 @@ class GTFS_Controller:
         config_path = f'{app_path}/config/config.yml'
         self.app_config = load_yaml_config(config_path, app_path=app_path)
         
+        gtfs_dbs_report_path = self.app_config['resource_paths']['gtfs_dbs_json_path']
+        gtfs_dbs_report_json = load_json_from_file(gtfs_dbs_report_path)
+        self.gtfs_dbs_report = GTFS_Static_Catalog_Report.from_json(gtfs_dbs_report_json)
+        
     def compare_latest_gtfs_rt_static(self):
         self._compare_compare_latest_gtfs_rt_static()
         
-    def load_gtfs_db(self, gtfs_db_dt: datetime):
-        return self._load_gtfs_db(gtfs_db_dt)
+    def load_gtfs_db(self, gtfs_catalog_item: GTFS_Static_Catalog_Item):
+        return self._load_gtfs_db(gtfs_catalog_item)
     
-    def compare_gtfs_rt_from_file(self, gtfs_static_db_dt: datetime, gtfs_rt_file_dt: datetime, gtfs_rt_path: Path, gtfs_db: GTFS_DB):
-        self._compare_gtfs_rt_from_file(gtfs_static_db_dt, gtfs_rt_file_dt, gtfs_rt_path, gtfs_db)
+    def compare_gtfs_rt_from_file(self, gtfs_rt_file_dt: datetime, gtfs_rt_path: Path, gtfs_catalog_item: GTFS_Static_Catalog_Item, gtfs_db: GTFS_DB):
+        self._compare_gtfs_rt_from_file(gtfs_rt_file_dt, gtfs_rt_path, gtfs_catalog_item, gtfs_db)
         
     def compute_gtfs_db_dt(self, dt: datetime):
-        return self._compute_gtfs_db_dt(dt)
+        return self._compute_gtfs_db_catalog_item(dt)
         
     # PRIVATE
     def _compare_compare_latest_gtfs_rt_static(self):
@@ -46,81 +51,98 @@ class GTFS_Controller:
         
         resource_path = self.app_config['resource_paths']['gtfs_rt_snapshot']
         gtfs_rt_snapshot_path = compute_resource_snapshot_path(resource_path, fetch_dt)
+
         gtfs_rt_response = fetch_latest(self.app_config, gtfs_rt_snapshot_path)
         
+        
         gtfs_rt_dt = datetime.fromtimestamp(gtfs_rt_response.header.timestamp)
-        
-        gtfs_db_dt = self._compute_gtfs_db_dt(gtfs_rt_dt)
-        
-        # wednesdays are special, the DB might not be ready yet
-        wed_week_idx = 2
-        if gtfs_rt_dt.weekday() == wed_week_idx:
-            gtfs_db_dt = self._rewind_gtfs_db_dt_if_needed(gtfs_db_dt)
+        gtfs_catalog_item = self._compute_gtfs_db_catalog_item(gtfs_rt_dt)
+        if gtfs_catalog_item is None:
+            print('WHOOPS - cant find a GTFS catalog item')
+            sys.exit(1)
             
-        gtfs_db = self._load_gtfs_db(gtfs_db_dt)
-        if gtfs_db is None:
-            gtfs_db_day = gtfs_db_dt.strftime('%Y-%m-%d')
-            print(f'ERROR: no DB found for {gtfs_db_day}')
-            return
-        
+        gtfs_db = self._load_gtfs_db(gtfs_catalog_item)
+            
         self._compare_file_gtfs_rt_static(
-            fetch_dt, gtfs_db_dt, 
-            gtfs_rt_snapshot_path, gtfs_rt_response, gtfs_db
+            fetch_dt,  
+            gtfs_rt_snapshot_path, gtfs_rt_response, 
+            gtfs_catalog_item, gtfs_db
         )
         
-    def _rewind_gtfs_db_dt_if_needed(self, gtfs_db_dt: datetime):
-        gtfs_db_day = gtfs_db_dt.strftime('%Y-%m-%d')
-        gtfs_db_filename = compute_gtfs_db_filename(gtfs_db_day)
-        gtfs_db_path: str = self.app_config['resource_paths']['gtfs_db']
-        gtfs_db_path = gtfs_db_path.replace('[GTFS_FILENAME]', gtfs_db_filename)
-        
-        if not os.path.isfile(gtfs_db_path):
-            gtfs_db_dt = gtfs_db_dt - timedelta(days=7)
-            
-        return gtfs_db_dt
-        
-    def _load_gtfs_db(self, gtfs_db_dt: datetime):
+    def _load_gtfs_db(self, gtfs_catalog_item: GTFS_Static_Catalog_Item):
         log_message(f'START GTFS lookups')
         
-        gtfs_day = gtfs_db_dt.strftime('%Y-%m-%d')
-        gtfs_db_filename = compute_gtfs_db_filename(gtfs_day)
-        log_message(f'... loading {gtfs_db_filename}')
-        gtfs_db_path: str = self.app_config['resource_paths']['gtfs_db']
-        gtfs_db_path = gtfs_db_path.replace('[GTFS_FILENAME]', gtfs_db_filename)
-        
+        gtfs_dbs_basepath = Path(self.app_config['resource_paths']['gtfs_db']).parent
+        gtfs_db_path = Path(f'{gtfs_dbs_basepath}/{gtfs_catalog_item.db_relative_path}')
+            
         if not os.path.isfile(gtfs_db_path):
+            print('WHOOPS - cant find DB at path')
+            print(gtfs_db_path)
             return None
-        
-        gtfs_db = GTFS_DB(gtfs_db_path, self.app_config['resource_paths'])
+
+        gtfs_db = GTFS_DB(db_path=gtfs_db_path, resources_path_config=self.app_config['resource_paths'])
         gtfs_db.init_lookups()
         
         log_message(f'... DONE GTFS lookups')
         
         return gtfs_db
     
-    def _compare_gtfs_rt_from_file(self, gtfs_static_db_dt: datetime, gtfs_rt_file_dt: datetime, gtfs_rt_path: Path, gtfs_db: GTFS_DB):
+    def _compare_gtfs_rt_from_file(self, gtfs_rt_file_dt: datetime, gtfs_rt_path: Path, gtfs_catalog_item: GTFS_Static_Catalog_Item, gtfs_db: GTFS_DB):
         log_message(f'... JSON path: {gtfs_rt_path}')
         
         gtfs_rt_json = load_json_from_file(gtfs_rt_path)
         gtfs_rt_response = GTFS_RT_Response.from_gtfs_rt_json(gtfs_rt_json)
         
         self._compare_file_gtfs_rt_static(
-            gtfs_rt_file_dt, gtfs_static_db_dt, 
-            gtfs_rt_path, gtfs_rt_response, gtfs_db
+            gtfs_rt_file_dt, gtfs_rt_path, gtfs_rt_response,
+            gtfs_catalog_item,
+            gtfs_db
         )
         
-    def _compare_file_gtfs_rt_static(self, report_dt: datetime, gtfs_db_dt: datetime, gtfs_rt_path: Path, gtfs_rt_response: GTFS_RT_Response, gtfs_db: GTFS_DB):
+    def _compute_gtfs_db_catalog_item(self, dt: datetime) -> Union[GTFS_Static_Catalog_Item, None]:
+        found_gtfs_db_item: Union[GTFS_Static_Catalog_Item, None] = None
+        for gtfs_db_item in self.gtfs_dbs_report.items:
+            # because the GTFS-RT is switch later, we need to use the switch time
+            gtfs_rt_switch_dt = datetime.strptime(gtfs_db_item.gtfs_rt_switch_datetime_s, '%Y-%m-%d %H:%M')
+            
+            # the request is for an older DB, ignore the DBs in the future
+            if gtfs_rt_switch_dt.timestamp() > dt.timestamp():
+                continue
+            
+            # ignore DBs that are not on disk
+            if gtfs_db_item.db_relative_path is None:
+                continue
+            
+            found_gtfs_db_item = gtfs_db_item
+            break # on first item
+        # loop GTFS DB catalog items
+        
+        return found_gtfs_db_item
+    
+    def _compare_file_gtfs_rt_static(self, 
+            report_dt: datetime, gtfs_rt_path: Path, gtfs_rt_response: GTFS_RT_Response, 
+            gtfs_catalog_item: GTFS_Static_Catalog_Item,
+            gtfs_db: GTFS_DB,
+        ):
         gtfs_rt_dt = datetime.fromtimestamp(gtfs_rt_response.header.timestamp)
         log_message(f'... RESPONSE')
         log_message(f'... rows: {len(gtfs_rt_response.entity)}')
         log_message(f'... TS RESPONSE   : {gtfs_rt_dt}')
         
-        gtfs_static_day = gtfs_db_dt.strftime('%Y-%m-%d')
+        gtfs_static_day = gtfs_catalog_item.gtfs_day
         gtfs_rt_age = round(gtfs_rt_dt.timestamp() - report_dt.timestamp())
+        
+        log_message(f'... STATIC DB DAY : {gtfs_static_day}')
+        log_message(f'... STATIC DB     : {gtfs_catalog_item.db_relative_path}')
+        
+        gtfs_db_dt = datetime.strptime(gtfs_catalog_item.gtfs_datetime_s, '%Y-%m-%d %H:%M')
+        gtfs_db_age = round((gtfs_rt_dt.timestamp() - gtfs_db_dt.timestamp()) / (3600 * 24), 2)
         
         report_metdata = GTFS_RT_Static_Report_Metadata(
             report_dt=report_dt,
             gtfs_db_filename=compute_gtfs_db_filename(gtfs_static_day),
+            gtfs_db_age=gtfs_db_age,
+            
             gtfs_rt_filename=gtfs_rt_path.name,
             gtfs_rt_ts=round(gtfs_rt_dt.timestamp()),
             gtfs_rt_dt=gtfs_rt_dt,
@@ -180,62 +202,3 @@ class GTFS_Controller:
         log_message(f'... saved to {report_path}')
         
         log_message('... DONE')
-        
-    def _compute_gtfs_db_dt(self, dt: datetime):
-        # GTFS static is published Wednesdays
-        wed_week_idx = 2
-        
-        days_since_last_wed = (dt.weekday() - wed_week_idx) % 7
-        
-        # ... around 5AM
-        if days_since_last_wed == 0:
-            dt_hhmm = dt.strftime('%H%M')
-            # at 6AM runs the cronjob for the new DB
-            if dt_hhmm < "0700":
-                days_since_last_wed = 7
-                
-        last_wed_dt = dt - timedelta(days=days_since_last_wed)
-        
-        return last_wed_dt
-        
-    def _compute_gtfs_db_filename_from_day(self, dt: datetime):
-        last_wed_dt = self._compute_gtfs_db_dt(dt)
-        
-        last_wed_day = last_wed_dt.strftime("%Y-%m-%d")      
-        gtfs_db_filename = compute_gtfs_db_filename(last_wed_day)
-        
-        return gtfs_db_filename
-    
-    def _load_gtfs_table(self, gtfs_db: SQLiteDBEngine, table_name: str, map_by_field: str = None):
-        res_cache_path_s: str = self.app_config['resource_paths']['cache_gtfs_db_table']
-        res_cache_path_s = res_cache_path_s.replace('[GTFS_FILENAME]', f'{gtfs_db.db_path.name}')
-        res_cache_path_s = res_cache_path_s.replace('[TABLE_NAME]', table_name)
-        res_cache_path = Path(res_cache_path_s)
-        
-        if os.path.isfile(res_cache_path):
-            res_json = load_json_from_file(res_cache_path)
-            return res_json
-        
-        sql = None
-        if table_name == 'trips':
-            sql = 'SELECT trip_id, route_id, service_id FROM trips'
-        if sql is None:
-            sql = f'SELECT * FROM {table_name}'
-            
-        res_json = gtfs_db.query(sql, map_by_field=map_by_field)
-        
-        export_json_to_file(res_json, res_cache_path, pretty_print=True)
-        
-        return res_json
-        
-    def _init_gtfs_db(self, gtfs_db_filename: str):
-        gtfs_db_path: str = self.app_config['resource_paths']['gtfs_db']
-        gtfs_db_path = gtfs_db_path.replace('[GTFS_FILENAME]', gtfs_db_filename)
-        
-        if not os.path.isfile(gtfs_db_path):
-            return None
-        
-        gtfs_db = GTFS_DB(gtfs_db_path, self.app_config['resource_paths'])
-        gtfs_db.init_lookups()
-        
-        return gtfs_db

--- a/tools/gtfs-rt-static-compare/compare_gtfs_rt_static/gtfs_controller.py
+++ b/tools/gtfs-rt-static-compare/compare_gtfs_rt_static/gtfs_controller.py
@@ -45,6 +45,8 @@ class GTFS_DB:
         self.map_trips: dict[str, TripDB] = {}
         for trip_id, trip_db_json in gtfs_trips_db.items():
             self.map_trips[trip_id] = TripDB(**trip_db_json)
+            # Dont use Trip because is slower init
+            # self.map_trips[trip_id] = Trip.init_from_db_row(trip_db_json, gtfs_calendar_db, gtfs_agency_db, gtfs_routes_db, gtfs_stops_db)
         
     def _load_gtfs_table(self, table_name: str, map_by_field: str = None):
         res_cache_path = None
@@ -70,7 +72,7 @@ class GTFS_DB:
             export_json_to_file(res_json, res_cache_path, pretty_print=True)
         
         return res_json
-        
+
 class GTFS_Controller:
     def __init__(self, app_path: Path):
         config_path = f'{app_path}/config/config.yml'

--- a/tools/gtfs-rt-static-compare/compare_gtfs_rt_static/gtfs_db.py
+++ b/tools/gtfs-rt-static-compare/compare_gtfs_rt_static/gtfs_db.py
@@ -1,0 +1,64 @@
+import os, sys
+
+from pathlib import Path
+
+from typing import Dict, Optional
+
+from .helpers.json_helpers import load_json_from_file, export_json_to_file
+from .helpers.db_engine import SQLiteDBEngine
+
+from .models.gtfs_static_db import Route as RouteDB
+from .models.gtfs_static_db import Trip as TripDB
+
+class GTFS_DB:
+    _db: SQLiteDBEngine
+    map_routes: Dict[str, RouteDB]
+    map_trips: Dict[str, TripDB]
+    _gtfs_db_table_cache_template: Optional[str]
+    
+    def __init__(self, db_path: Path, resources_path_config: Optional[Dict[str, str]]):
+        self._db = SQLiteDBEngine(db_path)
+        
+        self.map_routes = {}
+        self.map_routes = {}
+        
+        if resources_path_config is not None:
+            self._gtfs_db_table_cache_template = resources_path_config.get('cache_gtfs_db_table', None)
+            
+    def init_lookups(self):
+        gtfs_routes_db = self._load_gtfs_table('routes', map_by_field='route_id')
+        self.map_routes = {}
+        for route_id, route_db_json in gtfs_routes_db.items():
+            self.map_routes[route_id] = RouteDB(**route_db_json)        
+        
+        gtfs_trips_db = self._load_gtfs_table('trips', map_by_field='trip_id')
+        self.map_trips: dict[str, TripDB] = {}
+        for trip_id, trip_db_json in gtfs_trips_db.items():
+            self.map_trips[trip_id] = TripDB(**trip_db_json)
+            # Dont use Trip because is slower init
+            # self.map_trips[trip_id] = Trip.init_from_db_row(trip_db_json, gtfs_calendar_db, gtfs_agency_db, gtfs_routes_db, gtfs_stops_db)
+        
+    def _load_gtfs_table(self, table_name: str, map_by_field: str = None):
+        res_cache_path = None
+        if self._gtfs_db_table_cache_template is not None:
+            res_cache_path_s: str = f'{self._gtfs_db_table_cache_template}'
+            res_cache_path_s = res_cache_path_s.replace('[GTFS_FILENAME]', f'{self._db.db_path.name}')
+            res_cache_path_s = res_cache_path_s.replace('[TABLE_NAME]', table_name)
+            res_cache_path = Path(res_cache_path_s)
+        
+            if os.path.isfile(res_cache_path):
+                res_json = load_json_from_file(res_cache_path)
+                return res_json
+        
+        sql = None
+        if table_name == 'trips':
+            sql = 'SELECT trip_id, route_id, service_id FROM trips'
+        if sql is None:
+            sql = f'SELECT * FROM {table_name}'
+            
+        res_json = self._db.query(sql, map_by_field=map_by_field)
+        
+        if res_cache_path is not None:
+            export_json_to_file(res_json, res_cache_path, pretty_print=True)
+        
+        return res_json

--- a/tools/gtfs-rt-static-compare/compare_gtfs_rt_static/helpers/config_helpers.py
+++ b/tools/gtfs-rt-static-compare/compare_gtfs_rt_static/helpers/config_helpers.py
@@ -1,0 +1,1 @@
+../../../_shared/inc/helpers/config_helpers.py

--- a/tools/gtfs-rt-static-compare/compare_gtfs_rt_static/helpers/db_engine.py
+++ b/tools/gtfs-rt-static-compare/compare_gtfs_rt_static/helpers/db_engine.py
@@ -1,0 +1,1 @@
+../../../_shared/inc/helpers/db_engine.py

--- a/tools/gtfs-rt-static-compare/compare_gtfs_rt_static/helpers/gtfs_helpers.py
+++ b/tools/gtfs-rt-static-compare/compare_gtfs_rt_static/helpers/gtfs_helpers.py
@@ -1,0 +1,1 @@
+../../../_shared/inc/helpers/gtfs_helpers.py

--- a/tools/gtfs-rt-static-compare/compare_gtfs_rt_static/helpers/json_helpers.py
+++ b/tools/gtfs-rt-static-compare/compare_gtfs_rt_static/helpers/json_helpers.py
@@ -1,0 +1,1 @@
+../../../_shared/inc/helpers/json_helpers.py

--- a/tools/gtfs-rt-static-compare/compare_gtfs_rt_static/helpers/log_helpers.py
+++ b/tools/gtfs-rt-static-compare/compare_gtfs_rt_static/helpers/log_helpers.py
@@ -1,0 +1,1 @@
+../../../_shared/inc/helpers/log_helpers.py

--- a/tools/gtfs-rt-static-compare/compare_gtfs_rt_static/models/gtfs_rt.py
+++ b/tools/gtfs-rt-static-compare/compare_gtfs_rt_static/models/gtfs_rt.py
@@ -1,0 +1,1 @@
+../../../_shared/inc/models/gtfs_rt.py

--- a/tools/gtfs-rt-static-compare/compare_gtfs_rt_static/models/gtfs_rt_static_report.py
+++ b/tools/gtfs-rt-static-compare/compare_gtfs_rt_static/models/gtfs_rt_static_report.py
@@ -1,7 +1,7 @@
 import os, sys
 
 from dataclasses import dataclass, asdict
-from typing import List
+from typing import List, Dict
 from datetime import datetime
 
 from .gtfs_rt import Entity
@@ -69,5 +69,15 @@ class GTFS_RT_Static_Report:
     def as_json(self):
         data_json = asdict(self)
         data_json['metadata'] = self.metadata.as_json()
+        
+        return data_json
+    
+@dataclass
+class GTFS_RT_Static_Monthly_Report:
+    comments: str
+    report_days: Dict[str, Dict[str, GTFS_RT_Static_Report_Metadata]]
+    
+    def as_json(self):
+        data_json = asdict(self)
         
         return data_json

--- a/tools/gtfs-rt-static-compare/compare_gtfs_rt_static/models/gtfs_rt_static_report.py
+++ b/tools/gtfs-rt-static-compare/compare_gtfs_rt_static/models/gtfs_rt_static_report.py
@@ -10,6 +10,7 @@ from .gtfs_rt import Entity
 class GTFS_RT_Static_Report_Metadata:
     report_dt: datetime
     gtfs_db_filename: str
+    gtfs_db_age: float
     gtfs_rt_filename: str
     gtfs_rt_ts: int
     gtfs_rt_dt: datetime

--- a/tools/gtfs-rt-static-compare/compare_gtfs_rt_static/models/gtfs_rt_static_report.py
+++ b/tools/gtfs-rt-static-compare/compare_gtfs_rt_static/models/gtfs_rt_static_report.py
@@ -1,0 +1,73 @@
+import os, sys
+
+from dataclasses import dataclass, asdict
+from typing import List
+from datetime import datetime
+
+from .gtfs_rt import Entity
+
+@dataclass
+class GTFS_RT_Static_Report_Metadata:
+    report_dt: datetime
+    gtfs_db_filename: str
+    gtfs_rt_filename: str
+    gtfs_rt_ts: int
+    gtfs_rt_dt: datetime
+    gtfs_rt_age: int
+    
+    total_rows_no: int
+    tripOK_routeOK_no: int
+    tripOK_routeNOK_no: int
+    tripNOK_routeOK_no: int
+    tripNOK_routeNOK_no: int
+    
+    @staticmethod
+    def from_json(data_json):
+        metadata = GTFS_RT_Static_Report_Metadata(**data_json)
+        metadata.report_dt = datetime.strptime(metadata.report_dt, '%Y-%m-%d %H:%M:%S')
+        metadata.gtfs_rt_dt = datetime.strptime(metadata.gtfs_rt_dt, '%Y-%m-%d %H:%M:%S')
+        
+        return metadata
+    
+    def as_json(self):
+        data_json = asdict(self)
+        for metadata_key in ['report_dt', 'gtfs_rt_dt']:
+            metadata_dt: datetime = data_json[metadata_key]
+            data_json[metadata_key] = metadata_dt.strftime('%Y-%m-%d %H:%M:%S')
+        
+        return data_json
+
+@dataclass
+class GTFS_RT_Static_Report:
+    metadata: GTFS_RT_Static_Report_Metadata
+    
+    tripOK_routeNOK: List[str]
+    tripNOK_routeOK: List[str]
+    tripNOK_routeNOK: List[str]
+    
+    @staticmethod
+    def init_with_metadata(metdata: GTFS_RT_Static_Report_Metadata):
+        report = GTFS_RT_Static_Report(metdata, [], [], [])
+        return report
+    
+    @staticmethod
+    def from_json(report_json):
+        report = GTFS_RT_Static_Report(**report_json)
+        report.metadata = GTFS_RT_Static_Report_Metadata.from_json(report_json['metadata'])
+        
+        entity_group_keys = ['tripOK_routeNOK', 'tripNOK_routeOK', 'tripNOK_routeNOK']
+        for entity_group_key in entity_group_keys:
+            entity_ids = []
+            for entity_id in report_json[entity_group_key]:
+                entity_ids.append(entity_id)
+            
+            setattr(report, entity_group_key, entity_ids)
+        # entity_group_keys
+        
+        return report
+    
+    def as_json(self):
+        data_json = asdict(self)
+        data_json['metadata'] = self.metadata.as_json()
+        
+        return data_json

--- a/tools/gtfs-rt-static-compare/compare_gtfs_rt_static/models/gtfs_static
+++ b/tools/gtfs-rt-static-compare/compare_gtfs_rt_static/models/gtfs_static
@@ -1,0 +1,1 @@
+../../../_shared/inc/models/gtfs_static

--- a/tools/gtfs-rt-static-compare/compare_gtfs_rt_static/models/gtfs_static_db.py
+++ b/tools/gtfs-rt-static-compare/compare_gtfs_rt_static/models/gtfs_static_db.py
@@ -1,0 +1,1 @@
+../../../_shared/inc/models/gtfs_static_db.py

--- a/tools/gtfs-rt-static-compare/compare_gtfs_rt_static/models/gtfs_static_db_catalog.py
+++ b/tools/gtfs-rt-static-compare/compare_gtfs_rt_static/models/gtfs_static_db_catalog.py
@@ -1,0 +1,1 @@
+../../../_shared/inc/models/gtfs_static_db_catalog.py

--- a/tools/gtfs-rt-static-compare/config/config.yml
+++ b/tools/gtfs-rt-static-compare/config/config.yml
@@ -1,0 +1,11 @@
+resource_paths:
+  gtfs_rt_snapshot: [APP_PATH]/data/gtfs-rt-snapshot/[YEAR]/[MONTH]/[DAY]/GTFS_RT-[YEAR]-[MONTH]-[DAY]-[HHMM].json
+  gtfs_db: [APP_PATH]/data/gtfs-static-dbs/[GTFS_FILENAME]
+  cache_gtfs_db_table: [APP_PATH]/data/gtfs-rt-static-compare-tmp/[GTFS_FILENAME].[TABLE_NAME]-v1.json
+  gtfs_rt_static_report: [APP_PATH]/data/gtfs-rt-static-compare-report/[YEAR]/[MONTH]/[DAY]/gtfs_rt_static_report-[YEAR]-[MONTH]-[DAY]-[HHMM].json
+  gtfs_rt_static_mo_report: [APP_PATH]/data/gtfs-rt-static-compare-report/[YEAR]/[MONTH]/gtfs_rt_static_report-[YEAR]-[MONTH].html
+  gtfs_rt_static_mo_json: [APP_PATH]/data/gtfs-rt-static-compare-report/[YEAR]/gtfs_rt_static_report-[YEAR]-[MONTH].json
+
+opentransportdata:
+  key: eyJvcmciOiI2NDA2NTFhNTIyZmEwNTAwMDEyOWJiZTEiLCJpZCI6IjY2ZWIyNGRjMjJlNDQ4OGJhYzUxZDFkY2M4ZjhkMjFlIiwiaCI6Im11cm11cjEyOCJ9
+  gtfs_rt_url: https://api.opentransportdata.swiss/gtfsrt2020?FORMAT=json

--- a/tools/gtfs-rt-static-compare/config/config.yml
+++ b/tools/gtfs-rt-static-compare/config/config.yml
@@ -1,6 +1,7 @@
 resource_paths:
   gtfs_rt_snapshot: [APP_PATH]/data/gtfs-rt-snapshot/[YEAR]/[MONTH]/[DAY]/GTFS_RT-[YEAR]-[MONTH]-[DAY]-[HHMM].json
   gtfs_db: [APP_PATH]/data/gtfs-static-dbs/[GTFS_FILENAME]
+  gtfs_dbs_json_path: [APP_PATH]/data/gtfs-static-dbs/gtfs-static-dbs.json
   cache_gtfs_db_table: [APP_PATH]/data/gtfs-rt-static-compare-tmp/[GTFS_FILENAME].[TABLE_NAME]-v1.json
   gtfs_rt_static_report: [APP_PATH]/data/gtfs-rt-static-compare-report/[YEAR]/[MONTH]/[DAY]/gtfs_rt_static_report-[YEAR]-[MONTH]-[DAY]-[HHMM].json
   gtfs_rt_static_mo_report: [APP_PATH]/data/gtfs-rt-static-compare-report/[YEAR]/[MONTH]/gtfs_rt_static_report-[YEAR]-[MONTH].html

--- a/tools/gtfs-rt-static-compare/data/gtfs-rt-snapshot
+++ b/tools/gtfs-rt-static-compare/data/gtfs-rt-snapshot
@@ -1,0 +1,1 @@
+../../../data/gtfs-rt-snapshot

--- a/tools/gtfs-rt-static-compare/data/gtfs-rt-static-compare-report
+++ b/tools/gtfs-rt-static-compare/data/gtfs-rt-static-compare-report
@@ -1,0 +1,1 @@
+../../../data/gtfs-rt-static-compare-report

--- a/tools/gtfs-rt-static-compare/data/gtfs-rt-static-compare-tmp
+++ b/tools/gtfs-rt-static-compare/data/gtfs-rt-static-compare-tmp
@@ -1,0 +1,1 @@
+../../../data/gtfs-rt-static-compare-tmp

--- a/tools/gtfs-rt-static-compare/data/gtfs-static-dbs
+++ b/tools/gtfs-rt-static-compare/data/gtfs-static-dbs
@@ -1,0 +1,1 @@
+../../../data/gtfs-static-dbs

--- a/tools/gtfs-static-db-importer/cli_aggregate_dbs.py
+++ b/tools/gtfs-static-db-importer/cli_aggregate_dbs.py
@@ -1,0 +1,146 @@
+import os
+import sys
+from pathlib import Path
+
+from typing import Dict, List
+from datetime import datetime
+
+from inc.shared.inc.helpers.config_helpers import load_convenience_config
+from inc.shared.inc.models.gtfs_static_db_catalog import GTFS_Static_Catalog_Report, GTFS_Static_Catalog_Item
+from inc.shared.inc.models.ckan_data import CKAN_Data, CKAN_Resource
+from inc.shared.inc.helpers.json_helpers import export_json_to_file, load_json_from_file
+from inc.shared.inc.helpers.gtfs_helpers import compute_date_from_gtfs_db_filename, compute_datetime_from_gtfs_resource_filename
+from inc.shared.inc.helpers.db_engine import SQLiteDBEngine
+
+def main():
+    script_path = Path(os.path.realpath(__file__))
+    app_config = load_convenience_config(script_path)
+
+    _process(app_config)
+
+def _scan_local_dbs(app_config: any) -> Dict[str, Path]:
+    map_local_dbs = {}
+    
+    gtfs_dbs_base_path = Path(app_config['gtfs_dbs_base_path'])
+    gtfs_db_paths = gtfs_dbs_base_path.rglob('gtfs_*.sqlite')
+    
+    for gtfs_db_path in gtfs_db_paths:
+        gtfs_db_lock_path = Path(f'{gtfs_db_path}.lock')
+        if os.path.isfile(gtfs_db_lock_path):
+            continue
+        
+        gtfs_db_date = compute_date_from_gtfs_db_filename(gtfs_db_path.name)
+        if gtfs_db_date is None:
+            print('ERROR - cant extract day from filename')
+            print(gtfs_db_path.name)
+            sys.exit(1)
+            
+        gtfs_day = gtfs_db_date.strftime('%Y-%m-%d')
+        
+        relative_path = gtfs_db_path.relative_to(gtfs_dbs_base_path)
+        
+        map_local_dbs[gtfs_day] = relative_path
+        
+    return map_local_dbs
+
+def _load_ckan_data(app_config: any) -> List[CKAN_Resource]:
+    gtfs_ckan_json_path = app_config['gtfs_ckan_json_path']
+    gtfs_ckan_json = load_json_from_file(gtfs_ckan_json_path)
+    gtfs_ckan = CKAN_Data.from_ckan_json(gtfs_ckan_json)
+    
+    return gtfs_ckan.result.resources
+
+def _compute_map_gtfs_static_catalog(app_config) -> Dict[str, GTFS_Static_Catalog_Item]:
+    gtfs_static_db_path_report_path = app_config['gtfs_dbs_json_path']
+    
+    map_gtfs_catalog_items = {}
+    
+    if not os.path.isfile(gtfs_static_db_path_report_path):
+        return map_gtfs_catalog_items
+    
+    gtfs_static_db_path_report_json = load_json_from_file(gtfs_static_db_path_report_path)
+    gtfs_static_db_path_report = GTFS_Static_Catalog_Report.from_json(gtfs_static_db_path_report_json)
+    for gtfs_catalog_item in gtfs_static_db_path_report.items:
+        gtfs_db_day = gtfs_catalog_item.gtfs_day
+        map_gtfs_catalog_items[gtfs_db_day] = gtfs_catalog_item
+    
+    return map_gtfs_catalog_items
+    
+def _process(app_config: any):
+    map_gtfs_static_catalog = _compute_map_gtfs_static_catalog(app_config)
+    map_local_dbs = _scan_local_dbs(app_config)
+    ckan_data = _load_ckan_data(app_config)
+    
+    gtfs_dbs_base_path = Path(app_config['gtfs_dbs_base_path'])
+    
+    gtfs_rt_updates_splits_dt: List[datetime] = []
+    gtfs_rt_update_times: List[str] = []
+    for gtfs_update_interval_config in app_config['gtfs_rt_updates']:
+        to_dt = datetime.strptime(gtfs_update_interval_config['to'], '%Y-%m-%d')
+        gtfs_rt_updates_splits_dt.append(to_dt)
+        
+        gtfs_rt_update_times.append(gtfs_update_interval_config['switch'])
+    # loop app_config['gtfs_rt_updates']
+    
+    # loop through all CKAN resources and create new GTFS_Static_DB_Item objects if needed
+    for ckan_resource in ckan_data:
+        gtfs_dt = compute_datetime_from_gtfs_resource_filename(ckan_resource.identifier)
+        if gtfs_dt is None:
+            print(f'ERROR - cant extract GTFS day from resource: {ckan_resource.identifier}')
+            sys.exit(1)
+        
+        gtfs_day = gtfs_dt.strftime('%Y-%m-%d')
+        if gtfs_day in map_gtfs_static_catalog:
+            continue
+        
+        gtfs_db_relative_path = map_local_dbs.get(gtfs_day, None)
+        gtfs_dt_f = gtfs_dt.strftime('%Y-%m-%d %H:%M')
+        
+        gtfs_rt_update_time = gtfs_dt.strftime('%H:%M')
+        for idx, gtfs_rt_updates_split_dt in enumerate(gtfs_rt_updates_splits_dt):
+            if gtfs_dt.timestamp() < gtfs_rt_updates_split_dt.timestamp():
+                gtfs_rt_update_time = gtfs_rt_update_times[idx]
+                break
+        # loop gtfs_rt_updates_splits_dt
+        
+        gtfs_rt_switch_datetime_s = f'{gtfs_day} {gtfs_rt_update_time}'
+        
+        gtfs_catalog_item = GTFS_Static_Catalog_Item(
+            gtfs_datetime_s=gtfs_dt_f,
+            gtfs_day=gtfs_day,
+            gtfs_rt_switch_datetime_s=gtfs_rt_switch_datetime_s,
+            table_stats={}, # compute them in the next loop
+            db_relative_path=gtfs_db_relative_path,
+        )
+        
+        map_gtfs_static_catalog[gtfs_day] = gtfs_catalog_item
+    # loop ckan_resource in ckan_data
+    
+    # loop through all catalog items and validate if DB file is present locally
+    for gtfs_day, gtfs_catalog_item in map_gtfs_static_catalog.items():
+        gtfs_db_relative_path = map_local_dbs.get(gtfs_day, None)
+        if gtfs_db_relative_path is None:
+            gtfs_catalog_item.db_relative_path = None
+        else:
+            gtfs_catalog_item.db_relative_path = f'{gtfs_db_relative_path}' # format otherwise JSON encoder will scream
+        
+        # compute stats only if necessary
+        if gtfs_catalog_item.table_stats == {} and gtfs_db_relative_path is not None:
+            gtfs_db_path = f'{gtfs_dbs_base_path}/{gtfs_db_relative_path}'
+            gtfs_db_engine = SQLiteDBEngine(gtfs_db_path)
+            gtfs_catalog_item.table_stats = gtfs_db_engine.compute_table_stats()
+    
+    # build a list and sort descending by gtfs_day
+    gtfs_catalog_items = list(map_gtfs_static_catalog.values())
+    gtfs_catalog_items = sorted(gtfs_catalog_items, key=lambda x: x.gtfs_day, reverse=True)
+    
+    now_f = datetime.now().strftime('%Y-%m-%d %H:%M:%S')
+    metadata = f'Created at {now_f}'
+    gtfs_catalog = GTFS_Static_Catalog_Report(metadata, items=gtfs_catalog_items)
+    
+    gtfs_catalog_path = app_config['gtfs_dbs_json_path']
+    gtfs_catalog_json = gtfs_catalog.as_json()
+    export_json_to_file(gtfs_catalog_json, gtfs_catalog_path, pretty_print=True)
+    
+if __name__ == "__main__":
+    main()

--- a/tools/gtfs-static-db-importer/cli_aggregate_dbs.py
+++ b/tools/gtfs-static-db-importer/cli_aggregate_dbs.py
@@ -12,6 +12,8 @@ from inc.shared.inc.helpers.json_helpers import export_json_to_file, load_json_f
 from inc.shared.inc.helpers.gtfs_helpers import compute_date_from_gtfs_db_filename, compute_gtfs_day_from_resource_path
 from inc.shared.inc.helpers.db_engine import SQLiteDBEngine
 
+from inc.shared.inc.helpers.log_helpers import log_message
+
 def main():
     script_path = Path(os.path.realpath(__file__))
     app_config = load_convenience_config(script_path)
@@ -144,6 +146,8 @@ def _process(app_config: any):
     gtfs_catalog_path = app_config['gtfs_dbs_json_path']
     gtfs_catalog_json = gtfs_catalog.as_json()
     export_json_to_file(gtfs_catalog_json, gtfs_catalog_path, pretty_print=True)
+    
+    log_message(f'... saved to {gtfs_catalog_path}')    
     
 if __name__ == "__main__":
     main()

--- a/tools/gtfs-static-db-importer/cli_aggregate_dbs.py
+++ b/tools/gtfs-static-db-importer/cli_aggregate_dbs.py
@@ -9,7 +9,7 @@ from inc.shared.inc.helpers.config_helpers import load_convenience_config
 from inc.shared.inc.models.gtfs_static_db_catalog import GTFS_Static_Catalog_Report, GTFS_Static_Catalog_Item
 from inc.shared.inc.models.ckan_data import CKAN_Data, CKAN_Resource
 from inc.shared.inc.helpers.json_helpers import export_json_to_file, load_json_from_file
-from inc.shared.inc.helpers.gtfs_helpers import compute_date_from_gtfs_db_filename, compute_datetime_from_gtfs_resource_filename
+from inc.shared.inc.helpers.gtfs_helpers import compute_date_from_gtfs_db_filename, compute_gtfs_day_from_resource_path
 from inc.shared.inc.helpers.db_engine import SQLiteDBEngine
 
 def main():
@@ -84,41 +84,44 @@ def _process(app_config: any):
     
     # loop through all CKAN resources and create new GTFS_Static_DB_Item objects if needed
     for ckan_resource in ckan_data:
-        gtfs_dt = compute_datetime_from_gtfs_resource_filename(ckan_resource.identifier)
-        if gtfs_dt is None:
+        gtfs_day = compute_gtfs_day_from_resource_path(ckan_resource.identifier)
+        if gtfs_day is None:
             print(f'ERROR - cant extract GTFS day from resource: {ckan_resource.identifier}')
             sys.exit(1)
-        
-        gtfs_day = gtfs_dt.strftime('%Y-%m-%d')
-        if gtfs_day in map_gtfs_static_catalog:
+            
+        gtfs_day_f = f'{gtfs_day}'
+            
+        if gtfs_day_f in map_gtfs_static_catalog:
             continue
         
-        gtfs_db_relative_path = map_local_dbs.get(gtfs_day, None)
-        gtfs_dt_f = gtfs_dt.strftime('%Y-%m-%d %H:%M')
+        resource_dt = datetime.fromisoformat(ckan_resource.modified_s)
         
-        gtfs_rt_update_time = gtfs_dt.strftime('%H:%M')
+        gtfs_db_relative_path = map_local_dbs.get(gtfs_day_f, None)
+        gtfs_dt_f = resource_dt.strftime('%Y-%m-%d %H:%M')
+        
+        gtfs_rt_update_time = gtfs_day.strftime('%H:%M')
         for idx, gtfs_rt_updates_split_dt in enumerate(gtfs_rt_updates_splits_dt):
-            if gtfs_dt.timestamp() < gtfs_rt_updates_split_dt.timestamp():
+            if resource_dt.timestamp() < gtfs_rt_updates_split_dt.timestamp():
                 gtfs_rt_update_time = gtfs_rt_update_times[idx]
                 break
         # loop gtfs_rt_updates_splits_dt
         
-        gtfs_rt_switch_datetime_s = f'{gtfs_day} {gtfs_rt_update_time}'
+        gtfs_rt_switch_datetime_s = f'{gtfs_day_f} {gtfs_rt_update_time}'
         
         gtfs_catalog_item = GTFS_Static_Catalog_Item(
             gtfs_datetime_s=gtfs_dt_f,
-            gtfs_day=gtfs_day,
+            gtfs_day=gtfs_day_f,
             gtfs_rt_switch_datetime_s=gtfs_rt_switch_datetime_s,
             table_stats={}, # compute them in the next loop
             db_relative_path=gtfs_db_relative_path,
         )
         
-        map_gtfs_static_catalog[gtfs_day] = gtfs_catalog_item
+        map_gtfs_static_catalog[gtfs_day_f] = gtfs_catalog_item
     # loop ckan_resource in ckan_data
     
     # loop through all catalog items and validate if DB file is present locally
-    for gtfs_day, gtfs_catalog_item in map_gtfs_static_catalog.items():
-        gtfs_db_relative_path = map_local_dbs.get(gtfs_day, None)
+    for gtfs_day_f, gtfs_catalog_item in map_gtfs_static_catalog.items():
+        gtfs_db_relative_path = map_local_dbs.get(gtfs_day_f, None)
         if gtfs_db_relative_path is None:
             gtfs_catalog_item.db_relative_path = None
         else:

--- a/tools/gtfs-static-db-importer/data/ckan-utils-tmp
+++ b/tools/gtfs-static-db-importer/data/ckan-utils-tmp
@@ -1,0 +1,1 @@
+../../ckan-utils/tmp

--- a/tools/gtfs-static-db-importer/data/opentransportdata.swiss-gtfs-static
+++ b/tools/gtfs-static-db-importer/data/opentransportdata.swiss-gtfs-static
@@ -1,1 +1,0 @@
-../../../data/opentransportdata.swiss/gtfs-static

--- a/tools/gtfs-static-db-importer/data/opentransportdata.swiss-hrdf.5.40
+++ b/tools/gtfs-static-db-importer/data/opentransportdata.swiss-hrdf.5.40
@@ -1,1 +1,0 @@
-../../../data/opentransportdata.swiss/hrdf

--- a/tools/gtfs-static-db-importer/gtfs_db_importer_cli.py
+++ b/tools/gtfs-static-db-importer/gtfs_db_importer_cli.py
@@ -3,7 +3,7 @@ from pathlib import Path
 
 from inc.shared.inc.helpers.config_helpers import load_convenience_config
 from inc.db_importer import GTFS_DB_Importer
-from inc.shared.inc.helpers.gtfs_helpers import compute_formatted_date_from_gtfs_folder_path, compute_gtfs_db_filename
+from inc.shared.inc.helpers.gtfs_helpers import compute_gtfs_day_from_resource_path, compute_gtfs_db_filename
 
 def main():
     script_path = Path(os.path.realpath(__file__))
@@ -26,7 +26,7 @@ def main():
     if args.output_db_path:
         db_path = Path(args.output_db_path)
     else:
-        formatted_date = compute_formatted_date_from_gtfs_folder_path(gtfs_folder_path)  
+        formatted_date = compute_gtfs_day_from_resource_path(gtfs_folder_path)  
         if formatted_date is None:
             print(f"CANT read date from GTFS path: '{gtfs_folder_path}'")
             print(f"Use --output-db-path to override")

--- a/tools/gtfs-static-db-importer/inc/config.yml
+++ b/tools/gtfs-static-db-importer/inc/config.yml
@@ -5,4 +5,14 @@ map_sql_queries:
 
 gtfs_dbs_base_path: [APP_PATH]/data/gtfs-static-dbs
 gtfs_ckan_json_path: [APP_PATH]/data/ckan-utils-tmp/ckan_gtfs_static.json
+gtfs_dbs_json_path: [APP_PATH]/data/gtfs-static-dbs/gtfs-static-dbs.json
 
+gtfs_rt_updates:
+  -
+    # up to 10.04 the GTFS-RT switch was done at 13:05 in the day of GTFS static publish
+    to: "2024-04-10"
+    switch: "13:05"
+  -
+    # up to LATE-LATE the GTFS-RT switch was done at 15:05
+    to: "2099-12-31"
+    switch: "15:05"

--- a/tools/gtfs-static-db-importer/inc/config.yml
+++ b/tools/gtfs-static-db-importer/inc/config.yml
@@ -4,3 +4,5 @@ map_sql_queries:
   update_stop_times_reset: [APP_PATH]/inc/sql/update_stop_times_reset.sql
 
 gtfs_dbs_base_path: [APP_PATH]/data/gtfs-static-dbs
+gtfs_ckan_json_path: [APP_PATH]/data/ckan-utils-tmp/ckan_gtfs_static.json
+

--- a/tools/gtfs-static-db-importer/inc/db_importer.py
+++ b/tools/gtfs-static-db-importer/inc/db_importer.py
@@ -20,6 +20,7 @@ class GTFS_DB_Importer:
 
         self.gtfs_folder_path = gtfs_folder_path
         self.db_path = db_path
+        self.db_lock_path = Path(f'{self.db_path}.lock')
         self.db_handle = connect_db(db_path, is_read_only=False)
         self.db_schema_config = self._load_schema_config()
 
@@ -30,6 +31,13 @@ class GTFS_DB_Importer:
     def start(self):
         log_message("START GTFS IMPORT")
         log_message(f'DB PATH: {self.db_path}')
+        
+        if os.path.isfile(self.db_lock_path):
+            print('ERROR: lock path present, ABORT')
+            print(f'ls -al {self.db_lock_path.parent}')
+            sys.exit(1)
+        
+        self._write_lock_file()
 
         self._import_csv_tables()
         self._update_calendar()
@@ -37,6 +45,8 @@ class GTFS_DB_Importer:
         self._cleanup()
 
         self.db_handle.close()
+        
+        self._remove_lock_file()
 
         log_message("DONE GTFS IMPORT")
 
@@ -47,6 +57,16 @@ class GTFS_DB_Importer:
         db_schema_config = yaml.safe_load(open(db_schema_path, encoding='utf-8'))
 
         return db_schema_config
+    
+    def _write_lock_file(self):
+        now_f = datetime.datetime.now().strftime('%Y-%m-%d %H:%M:%S')
+        lock_file_text = f'START: {now_f}'
+        lock_file = open(self.db_lock_path, 'w', encoding='utf-8')
+        lock_file.write(lock_file_text)
+        lock_file.close()
+        
+    def _remove_lock_file(self):
+        os.remove(self.db_lock_path)
 
     def _import_csv_tables(self):
         table_names = ['agency', 'calendar', 'calendar_dates', 'routes', 'shapes', 'stop_times', 'stops', 'trips']

--- a/tools/scripts/gtfs-compute-latest.py
+++ b/tools/scripts/gtfs-compute-latest.py
@@ -81,6 +81,9 @@ def _db_import(app_config, script_path, gtfs_data_path):
     return gtfs_db_path
 
 def _dbs_aggregate(script_path):
+    print(f'')
+    print(f'STEP 4 - BUILD GTFS DB catalog')
+    
     cli_path = f'{script_path.parent}/../gtfs-static-db-importer/cli_aggregate_dbs.py'
     cli_sh = f'python3 {cli_path}'
     print(cli_sh, flush=True)

--- a/tools/scripts/gtfs-compute-latest.py
+++ b/tools/scripts/gtfs-compute-latest.py
@@ -3,11 +3,10 @@ import glob
 from pathlib import Path
 
 from inc.shared.inc.helpers.config_helpers import load_convenience_config
-from inc.shared.inc.helpers.gtfs_helpers import compute_formatted_date_from_gtfs_folder_path, compute_gtfs_db_filename
 from inc.shared.inc.helpers.json_helpers import load_json_from_file
+from inc.shared.inc.helpers.gtfs_helpers import compute_gtfs_day_from_resource_path, compute_gtfs_db_filename
 from inc.shared.inc.models.ckan_data import CKAN_Data
 
-# .hrdf_helpers import compute_formatted_date_from_hrdf_folder_path, compute_hrdf_db_filename, compute_formatted_date_from_hrdf_db_path
 row_delimiter_s = '='*70
 
 def main():
@@ -58,7 +57,7 @@ def _check_latest_data_folder(app_config):
     return resource_path
 
 def _db_import(app_config, script_path, gtfs_data_path):
-    gtfs_day = compute_formatted_date_from_gtfs_folder_path(gtfs_data_path)
+    gtfs_day = compute_gtfs_day_from_resource_path(gtfs_data_path)
     gtfs_dbs_path = app_config['data_paths']['gtfs-static-dbs']
     gtfs_db_filename = compute_gtfs_db_filename(gtfs_day)
     gtfs_db_path = f'{gtfs_dbs_path}/{gtfs_db_filename}'

--- a/tools/scripts/gtfs-compute-latest.py
+++ b/tools/scripts/gtfs-compute-latest.py
@@ -15,6 +15,8 @@ def main():
     gtfs_data_path = _check_latest_data_folder(app_config)
     _db_import(app_config, script_path, gtfs_data_path)
     
+    _dbs_aggregate(script_path)
+    
 def _fetch_latest_resource(script_path, package_key):
     # fetch latest archive
     ckan_fetch_cli_path = f'{script_path.parent}/../ckan-utils/fetch_package_cli.py'
@@ -77,6 +79,12 @@ def _db_import(app_config, script_path, gtfs_data_path):
         os.system(import_sh)
 
     return gtfs_db_path
+
+def _dbs_aggregate(script_path):
+    cli_path = f'{script_path.parent}/../gtfs-static-db-importer/cli_aggregate_dbs.py'
+    cli_sh = f'python3 {cli_path}'
+    print(cli_sh, flush=True)
+    os.system(cli_sh)
 
 if __name__ == "__main__":
     main()

--- a/tools/scripts/gtfs-compute-latest.py
+++ b/tools/scripts/gtfs-compute-latest.py
@@ -4,8 +4,11 @@ from pathlib import Path
 
 from inc.shared.inc.helpers.config_helpers import load_convenience_config
 from inc.shared.inc.helpers.gtfs_helpers import compute_formatted_date_from_gtfs_folder_path, compute_gtfs_db_filename
+from inc.shared.inc.helpers.json_helpers import load_json_from_file
+from inc.shared.inc.models.ckan_data import CKAN_Data
 
 # .hrdf_helpers import compute_formatted_date_from_hrdf_folder_path, compute_hrdf_db_filename, compute_formatted_date_from_hrdf_db_path
+row_delimiter_s = '='*70
 
 def main():
     script_path = Path(os.path.realpath(__file__))
@@ -30,33 +33,29 @@ def _fetch_latest_resource(script_path, package_key):
 def _check_latest_data_folder(app_config):
     # check latest folder
     print('')
-    hrdf_data_base_folder_path = app_config['data_paths']['gtfs-static']
-    resource_paths = glob.glob(f'{hrdf_data_base_folder_path}/*')
-    resource_paths.sort(reverse=True)
-
-    gtfs_data_path = None
-    gtfs_day = None
-    for resource_path in resource_paths:
-        if not os.path.isdir(resource_path):
-            continue
-
-        resource_path = Path(resource_path)
-        gtfs_day = compute_formatted_date_from_gtfs_folder_path(resource_path.name)
-        if gtfs_day is None:
-            continue
-
-        gtfs_data_path = resource_path
-        break
-
-    if gtfs_data_path is None:
-        print(f'ERROR - cant find a new GTFS folder data in {hrdf_data_base_folder_path}')
-        sys.exit()
-
-    print(f'=> found {gtfs_data_path}')
-    print(f'=> GTFS day {gtfs_day}')
     print('STEP 2 - CHECK LATEST GTFS DATASET')
     
-    return gtfs_data_path
+    gtfs_ckan_json_path = app_config['resource_paths']['ckan_gtfs_static_json']
+    gtfs_ckan_json = load_json_from_file(gtfs_ckan_json_path)
+    gtfs_ckan = CKAN_Data.from_ckan_json(gtfs_ckan_json)
+    
+    ckan_resource = gtfs_ckan.result.resources[0]
+    
+    resources_base_folder_path = app_config['data_paths']['gtfs-static']
+    resource_folder_name = ckan_resource.title['en'][0:-4]
+    resource_path = Path(f'{resources_base_folder_path}/{resource_folder_name}')
+    
+    if not os.path.isdir(resource_path):
+        print()
+        print(row_delimiter_s)
+        print('ERROR - latest resource not found at path')
+        print(resource_path)
+        print(row_delimiter_s)
+        sys.exit(1)
+        
+    print(f'... use following resource: {resource_path}')
+        
+    return resource_path
 
 def _db_import(app_config, script_path, gtfs_data_path):
     gtfs_day = compute_formatted_date_from_gtfs_folder_path(gtfs_data_path)

--- a/tools/scripts/gtfs-compute-latest.py
+++ b/tools/scripts/gtfs-compute-latest.py
@@ -30,7 +30,6 @@ def _fetch_latest_resource(script_path, package_key):
 def _check_latest_data_folder(app_config):
     # check latest folder
     print('')
-    print('STEP 2 - CHCEK LATEST FOLDER')
     hrdf_data_base_folder_path = app_config['data_paths']['gtfs-static']
     resource_paths = glob.glob(f'{hrdf_data_base_folder_path}/*')
     resource_paths.sort(reverse=True)
@@ -55,6 +54,7 @@ def _check_latest_data_folder(app_config):
 
     print(f'=> found {gtfs_data_path}')
     print(f'=> GTFS day {gtfs_day}')
+    print('STEP 2 - CHECK LATEST GTFS DATASET')
     
     return gtfs_data_path
 

--- a/tools/scripts/hrdf-compute-latest.py
+++ b/tools/scripts/hrdf-compute-latest.py
@@ -31,7 +31,7 @@ def _fetch_latest_resource(script_path, package_key):
 def _check_latest_data_folder(app_config):
     # check latest folder
     print('')
-    print('STEP 2 - CHCEK LATEST FOLDER')
+    print('STEP 2 - CHECK LATEST FOLDER')
     hrdf_data_base_folder_path = app_config['data_paths']['hrdf-opentransportdata.swiss']
     resource_paths = glob.glob(f'{hrdf_data_base_folder_path}/*')
     resource_paths.sort(reverse=True)

--- a/tools/scripts/inc/config.yml
+++ b/tools/scripts/inc/config.yml
@@ -12,3 +12,6 @@ data_paths:
   hrdf-db-lookups: [APP_PATH]/data/hrdf-db-lookups
   hrdf-duplicates-reports: [APP_PATH]/data/hrdf-duplicates-reports
   hrdf-duplicates-reports-csv: [APP_PATH]/data/hrdf-duplicates-reports/hrdf-duplicates-reports-csv
+
+resource_paths:
+  ckan_gtfs_static_json: [APP_PATH]/data/ckan-utils-tmp/ckan_gtfs_static.json

--- a/tools/scripts/inc/config.yml
+++ b/tools/scripts/inc/config.yml
@@ -1,4 +1,8 @@
 data_paths:
+  gtfs-db-lookups: [APP_PATH]/data/gtfs-db-lookups
+  gtfs-rt-snapshot: [APP_PATH]/data/gtfs-rt-snapshot
+  gtfs-rt-static-compare-report: [APP_PATH]/data/gtfs-rt-static-compare-report
+  gtfs-rt-static-compare-tmp: [APP_PATH]/data/gtfs-rt-static-compare-tmp
   gtfs-static: &GTFS_STATIC_DATA_PATH [APP_PATH]/data/opentransportdata.swiss/gtfs-static
   gtfs-static-dbs: &GTFS_STATIC_DBS_PATH [APP_PATH]/data/gtfs-static-dbs
   gtfs-query-db-cache: [APP_PATH]/data/gtfs-query-db-cache


### PR DESCRIPTION
- adds Python models
  - `CKAN_Resource`, `CKAN_Result` - for CKAN JSON API objects
  - `GTFS_RT_Response` + rest of GTFS RT JSON models
  - `Route`, `Trip` for GTFS static DB table objects
  - `GTFS_Static_Catalog_Report`, `GTFS_Static_Catalog_Item` for GTFS static DBs metadata
  - `GTFS_RT_Static_Report`, `GTFS_RT_Static_Report_Metadata` for GTFS static - GTFS RT reports
- adds new Python tool `gtfs-rt-static-compare`
   - `cli_compare_latest.py` - compare latest GTFS RT / GTFS static dataset
   - `cli_aggregate_monthly_reports_json.py` - generates metadata report for the current or given month
- adds `cli_aggregate_dbs.py` in `gtfs-static-db-importer` tool for generating DBs metadata report of the local GTFS databases
- adds a lock mechanism when importing GTFS DBs so they are used by other tools only when the import is done
- updates `CKAN_Controller` to use the new models
- updates the helper for computing GTFS day to return `date` objects, adapt the tools to use the new helper
- adds `SQLiteDBEngine` helper for connecting / query SQL DBs
