### PR TITLE
Fix gtfs-rt-static-compare

### DIFF
--- a/tools/gtfs-rt-static-compare/cli_batch_compare.py
+++ b/tools/gtfs-rt-static-compare/cli_batch_compare.py
@@ -77,7 +77,8 @@ def main():
 
         file_idx = 0
         for gtfs_rt_file_key, gtfs_rt_file_path in map_gtfs_rt_file_paths.items():
-            log_message(f'... PROCESSING {file_idx} / {gtfs_rt_files_no}: {gtfs_rt_file_path.name}')
+            if file_idx % 10 == 0:
+                log_message(f'... PROCESSING {file_idx} / {gtfs_rt_files_no}: {gtfs_rt_file_path.name}')
 
             gtfs_rt_file_dt = datetime.strptime(f'{gtfs_rt_file_key}', '%Y-%m-%d %H%M')
             gtfs_controller.compare_gtfs_rt_from_file(gtfs_rt_file_dt, gtfs_rt_file_path, gtfs_catalog_item, gtfs_db)

--- a/tools/gtfs-rt-static-compare/cli_batch_compare.py
+++ b/tools/gtfs-rt-static-compare/cli_batch_compare.py
@@ -1,0 +1,95 @@
+import os, sys
+
+import re
+import argparse
+
+from pathlib import Path
+from typing import Dict, List
+from datetime import datetime
+
+from compare_gtfs_rt_static.gtfs_controller import GTFS_Controller
+from compare_gtfs_rt_static.models.gtfs_static_db_catalog import GTFS_Static_Catalog_Item
+from compare_gtfs_rt_static.helpers.log_helpers import log_message
+
+def main():
+    app_path = Path(os.path.realpath(__file__)).parent
+    
+    report_now = datetime.now()
+    report_ym = report_now.strftime('%Y-%m')
+    
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--month', '--month', default=report_ym)
+    args = parser.parse_args()
+    
+    report_ym = args.month
+
+    gtfs_rt_snapshot_files_path = Path(f'{app_path}/data/gtfs-rt-snapshot')
+    
+    gtfs_rt_file_paths: List[Path] = []
+    for gtfs_rt_file_path in gtfs_rt_snapshot_files_path.rglob('*.json'):
+        gtfs_rt_file_paths.append(gtfs_rt_file_path)
+    gtfs_rt_file_paths.sort()
+    
+    gtfs_controller = GTFS_Controller(app_path)
+    
+    map_db_catalog_items: Dict[str, GTFS_Static_Catalog_Item] = {}
+    map_file_file_paths: Dict[str, Dict[str, Path]] = {}
+    for gtfs_rt_file_path in gtfs_rt_file_paths:
+        keep_file = False
+        if gtfs_rt_file_path.name.startswith(f'GTFS_RT-{report_ym}'):
+            keep_file = True
+        if not keep_file:
+            continue
+        
+        file_matches = re.match(r"GTFS_RT-([0-9]{4}-[0-9]{2}-[0-9]{2})-([0-9]{4})\.", gtfs_rt_file_path.name)
+        if file_matches is None:
+            continue
+        
+        file_date_f = file_matches[1]
+        file_hhmm = file_matches[2]
+        file_dt = datetime.strptime(f'{file_date_f} {file_hhmm}', '%Y-%m-%d %H%M')
+        
+        gtfs_catalog_item = gtfs_controller.compute_gtfs_db_dt(file_dt)
+        gtfs_day = gtfs_catalog_item.gtfs_day
+        
+        if gtfs_day not in map_file_file_paths:
+            map_file_file_paths[gtfs_day] = {}
+            
+        gtfs_rt_file_key = f'{file_date_f} {file_hhmm}'
+            
+        map_file_file_paths[gtfs_day][gtfs_rt_file_key] = gtfs_rt_file_path
+        map_db_catalog_items[gtfs_day] = gtfs_catalog_item
+    # loop files
+    
+    for gtfs_day, map_gtfs_rt_file_paths in map_file_file_paths.items():
+        gtfs_catalog_item = map_db_catalog_items[gtfs_day]
+        if gtfs_catalog_item.db_relative_path is None:
+            continue
+        
+        log_message(f'GTFS DB DT {gtfs_day}')
+        log_message(f'... START GTFS lookups')
+        gtfs_db = gtfs_controller.load_gtfs_db(gtfs_catalog_item)
+        log_message(f'... DONE')
+        print()
+        
+        gtfs_rt_files_no = len(map_gtfs_rt_file_paths.keys())
+        log_message(f'... {gtfs_rt_files_no} GTFS RT files')        
+
+        file_idx = 0
+        for gtfs_rt_file_key, gtfs_rt_file_path in map_gtfs_rt_file_paths.items():
+            log_message(f'... PROCESSING {file_idx} / {gtfs_rt_files_no}: {gtfs_rt_file_path.name}')
+
+            gtfs_rt_file_dt = datetime.strptime(f'{gtfs_rt_file_key}', '%Y-%m-%d %H%M')
+            gtfs_controller.compare_gtfs_rt_from_file(gtfs_rt_file_dt, gtfs_rt_file_path, gtfs_catalog_item, gtfs_db)
+            file_idx += 1
+        # loop gtfs_rt files
+        print()
+            
+        log_message('... DONE GTFS DB')
+        print()
+    # loop GTFS dbs
+    
+    log_message('DONE LOOP')
+
+if __name__ == "__main__":
+    main()

--- a/tools/gtfs-rt-static-compare/cli_batch_compare.py
+++ b/tools/gtfs-rt-static-compare/cli_batch_compare.py
@@ -50,6 +50,9 @@ def main():
         file_dt = datetime.strptime(f'{file_date_f} {file_hhmm}', '%Y-%m-%d %H%M')
         
         gtfs_catalog_item = gtfs_controller.compute_gtfs_db_dt(file_dt)
+        if gtfs_catalog_item is None:
+            continue
+        
         gtfs_day = gtfs_catalog_item.gtfs_day
         
         if gtfs_day not in map_file_file_paths:

--- a/tools/gtfs-rt-static-compare/compare_gtfs_rt_static/fetch.py
+++ b/tools/gtfs-rt-static-compare/compare_gtfs_rt_static/fetch.py
@@ -17,13 +17,13 @@ def fetch_latest(app_config: dict, gtfs_rt_snapshot_path: Path):
     
     return gtfs_rt_response
 
-def compute_resource_snapshot_path(resource_path: str, fetch_dt: datetime):
+def compute_resource_snapshot_path(resource_path_template: str, fetch_dt: datetime):
     dt_year = fetch_dt.strftime('%Y')
     dt_month = fetch_dt.strftime('%m')
     dt_day = fetch_dt.strftime('%d')
     dt_hhmm = fetch_dt.strftime('%H%M')
     
-    resource_path = resource_path.replace('[YEAR]', dt_year)
+    resource_path = resource_path_template.replace('[YEAR]', dt_year)
     resource_path = resource_path.replace('[MONTH]', dt_month)
     resource_path = resource_path.replace('[DAY]', dt_day)
     resource_path = resource_path.replace('[HHMM]', dt_hhmm)

--- a/tools/gtfs-rt-static-compare/compare_gtfs_rt_static/gtfs_controller.py
+++ b/tools/gtfs-rt-static-compare/compare_gtfs_rt_static/gtfs_controller.py
@@ -153,6 +153,7 @@ class GTFS_Controller:
             tripOK_routeNOK_no=0,
             tripNOK_routeOK_no=0,
             tripNOK_routeNOK_no=0,
+            tripNOK_NOJP_no=0
         )
         
         report_stats = GTFS_RT_Static_Report.init_with_metadata(report_metdata)
@@ -180,6 +181,11 @@ class GTFS_Controller:
             if not trip_OK and not route_OK:
                 report_stats.tripNOK_routeNOK.append(entity.id)
                 report_stats.metadata.tripNOK_routeNOK_no += 1
+            
+            # match tripId that DOESNT start with 'ojp:' 'atv:'
+            special_trip_id_matches = re.match('^[a-z]{3}:', trip_id)
+            if not trip_OK and not special_trip_id_matches:
+                report_stats.metadata.tripNOK_NOJP_no += 1
         # loop entity
 
         print(f'age                 : {gtfs_rt_age}')

--- a/tools/gtfs-rt-static-compare/compare_gtfs_rt_static/gtfs_controller.py
+++ b/tools/gtfs-rt-static-compare/compare_gtfs_rt_static/gtfs_controller.py
@@ -2,7 +2,9 @@ import os, sys
 
 from pathlib import Path
 
-from typing import Union, List
+import re
+
+from typing import Union
 
 from datetime import datetime
 
@@ -51,9 +53,8 @@ class GTFS_Controller:
         
         resource_path = self.app_config['resource_paths']['gtfs_rt_snapshot']
         gtfs_rt_snapshot_path = compute_resource_snapshot_path(resource_path, fetch_dt)
-
-        gtfs_rt_response = fetch_latest(self.app_config, gtfs_rt_snapshot_path)
         
+        gtfs_rt_response = fetch_latest(self.app_config, gtfs_rt_snapshot_path)
         
         gtfs_rt_dt = datetime.fromtimestamp(gtfs_rt_response.header.timestamp)
         gtfs_catalog_item = self._compute_gtfs_db_catalog_item(gtfs_rt_dt)
@@ -70,8 +71,6 @@ class GTFS_Controller:
         )
         
     def _load_gtfs_db(self, gtfs_catalog_item: GTFS_Static_Catalog_Item):
-        log_message(f'START GTFS lookups')
-        
         gtfs_dbs_basepath = Path(self.app_config['resource_paths']['gtfs_db']).parent
         gtfs_db_path = Path(f'{gtfs_dbs_basepath}/{gtfs_catalog_item.db_relative_path}')
             
@@ -83,13 +82,9 @@ class GTFS_Controller:
         gtfs_db = GTFS_DB(db_path=gtfs_db_path, resources_path_config=self.app_config['resource_paths'])
         gtfs_db.init_lookups()
         
-        log_message(f'... DONE GTFS lookups')
-        
         return gtfs_db
     
     def _compare_gtfs_rt_from_file(self, gtfs_rt_file_dt: datetime, gtfs_rt_path: Path, gtfs_catalog_item: GTFS_Static_Catalog_Item, gtfs_db: GTFS_DB):
-        log_message(f'... JSON path: {gtfs_rt_path}')
-        
         gtfs_rt_json = load_json_from_file(gtfs_rt_path)
         gtfs_rt_response = GTFS_RT_Response.from_gtfs_rt_json(gtfs_rt_json)
         
@@ -125,15 +120,9 @@ class GTFS_Controller:
             gtfs_db: GTFS_DB,
         ):
         gtfs_rt_dt = datetime.fromtimestamp(gtfs_rt_response.header.timestamp)
-        log_message(f'... RESPONSE')
-        log_message(f'... rows: {len(gtfs_rt_response.entity)}')
-        log_message(f'... TS RESPONSE   : {gtfs_rt_dt}')
         
         gtfs_static_day = gtfs_catalog_item.gtfs_day
         gtfs_rt_age = round(gtfs_rt_dt.timestamp() - report_dt.timestamp())
-        
-        log_message(f'... STATIC DB DAY : {gtfs_static_day}')
-        log_message(f'... STATIC DB     : {gtfs_catalog_item.db_relative_path}')
         
         gtfs_db_dt = datetime.strptime(gtfs_catalog_item.gtfs_datetime_s, '%Y-%m-%d %H:%M')
         gtfs_db_age = round((gtfs_rt_dt.timestamp() - gtfs_db_dt.timestamp()) / (3600 * 24), 2)
@@ -187,24 +176,11 @@ class GTFS_Controller:
             if not trip_OK and not special_trip_id_matches:
                 report_stats.metadata.tripNOK_NOJP_no += 1
         # loop entity
-
-        print(f'age                 : {gtfs_rt_age}')
-        if abs(gtfs_rt_age) > 60:
-            print(f'                    : ERROR, TOO OLD')
-            print(f'                    : ' + gtfs_rt_dt.strftime('%Y-%m-%d %H:%M:%S'))
-            print(f'                    : ' + report_dt.strftime('%Y-%m-%d %H:%M:%S'))
-            print()
-        print(f'rows                : {report_stats.metadata.total_rows_no}')
-        print(f'OK                  : {report_stats.metadata.tripOK_routeOK_no}')
-        print(f'tripOK  - routeNOT  : {len(report_stats.tripOK_routeNOK)}')
-        print(f'tripNOT - routeOK   : {len(report_stats.tripNOK_routeOK)}')
-        print(f'tripNOT - routeNOT  : {len(report_stats.tripNOK_routeNOK)}')
-        print()
         
         report_path = self.app_config['resource_paths']['gtfs_rt_static_report']
         report_path = compute_resource_snapshot_path(report_path, report_dt)
         report_json = report_stats.as_json()
         export_json_to_file(report_json, report_path, pretty_print=True)
-        log_message(f'... saved to {report_path}')
-        
-        log_message('... DONE')
+
+        return report_stats
+    # _compare_file_gtfs_rt_static

--- a/tools/gtfs-rt-static-compare/compare_gtfs_rt_static/gtfs_controller.py
+++ b/tools/gtfs-rt-static-compare/compare_gtfs_rt_static/gtfs_controller.py
@@ -86,16 +86,14 @@ class GTFS_Controller:
         print(header_separator_s)
         log_message('GTFS-RT <-> GTFS-STATIC Report')
         print(header_separator_s)
-        
         print(f'GTFS-RT age         : {report.metadata.gtfs_rt_age} seconds')
         print(f'GTFS-static DB age  : {report.metadata.gtfs_db_age} days')
         print()
-        
-        print(f'GTFS-RT     rows no : {report.metadata.total_rows_no}')
-        print(f'           trips OK : {report.metadata.tripOK_routeOK_no}')
+        print(f'rows no             : {report.metadata.total_rows_no}')
+        print(f'trips OK            : {report.metadata.tripOK_routeOK_no}')
         print()
-        print(f' tripOK_routeNOK_no : {report.metadata.tripOK_routeNOK_no}')
-        print(f' tripNOK_routeOK_no : {report.metadata.tripNOK_routeOK_no}')
+        print(f'tripOK_routeNOK_no  : {report.metadata.tripOK_routeNOK_no}')
+        print(f'tripNOK_routeOK_no  : {report.metadata.tripNOK_routeOK_no}')
         print(f'tripNOK_routeNOK_no : {report.metadata.tripNOK_routeNOK_no}')
         print(f'tripNOK_NOJP_no     : {report.metadata.tripNOK_NOJP_no}')
         print()
@@ -107,10 +105,10 @@ class GTFS_Controller:
         dt_month = fetch_dt.strftime('%m')
         dt_day = fetch_dt.strftime('%d')
         report_url = f'https://tools.odpch.ch/gtfs-rt-static-compare-report/{dt_year}/{dt_month}/{dt_day}/{report_path.name}';
-        print(f'tripNOK_NOJP_no     : {report_url}')
-        print()
+        print(f'Report URL          : {report_url}')
+        print(header_separator_s)
         
-        print(f'saved to {report_path}')
+        print(f'... saved to {report_path}')
         print(header_separator_s)
         
         log_message('... DONE')

--- a/tools/gtfs-rt-static-compare/compare_gtfs_rt_static/gtfs_controller.py
+++ b/tools/gtfs-rt-static-compare/compare_gtfs_rt_static/gtfs_controller.py
@@ -44,7 +44,11 @@ class GTFS_Controller:
         
     # PRIVATE
     def _compare_compare_latest_gtfs_rt_static(self):
+        header_separator_s = '-' * 60
+        
+        print(header_separator_s)
         log_message(f'START COMPARE GTFS -RT GTFS STATIC')
+        print(header_separator_s)
         
         fetch_dt = datetime.now()
         
@@ -55,6 +59,9 @@ class GTFS_Controller:
         gtfs_rt_snapshot_path = compute_resource_snapshot_path(resource_path, fetch_dt)
         
         gtfs_rt_response = fetch_latest(self.app_config, gtfs_rt_snapshot_path)
+        log_message(f'... DONE fetch')
+        print(f'saved to {gtfs_rt_snapshot_path}')
+        print(header_separator_s)
         
         gtfs_rt_dt = datetime.fromtimestamp(gtfs_rt_response.header.timestamp)
         gtfs_catalog_item = self._compute_gtfs_db_catalog_item(gtfs_rt_dt)
@@ -62,13 +69,51 @@ class GTFS_Controller:
             print('WHOOPS - cant find a GTFS catalog item')
             sys.exit(1)
             
-        gtfs_db = self._load_gtfs_db(gtfs_catalog_item)
+        log_message(f'... LOAD DB GTFS-DAY: {gtfs_catalog_item.gtfs_day} - {gtfs_catalog_item.db_relative_path}')
             
-        self._compare_file_gtfs_rt_static(
+        gtfs_db = self._load_gtfs_db(gtfs_catalog_item)
+        
+        log_message(f'... DONE LOAD DB')
+        print(header_separator_s)
+        
+        report = self._compare_file_gtfs_rt_static(
             fetch_dt,  
             gtfs_rt_snapshot_path, gtfs_rt_response, 
             gtfs_catalog_item, gtfs_db
         )
+        
+        print()
+        print(header_separator_s)
+        log_message('GTFS-RT <-> GTFS-STATIC Report')
+        print(header_separator_s)
+        
+        print(f'GTFS-RT age         : {report.metadata.gtfs_rt_age} seconds')
+        print(f'GTFS-static DB age  : {report.metadata.gtfs_db_age} days')
+        print()
+        
+        print(f'GTFS-RT     rows no : {report.metadata.total_rows_no}')
+        print(f'           trips OK : {report.metadata.tripOK_routeOK_no}')
+        print()
+        print(f' tripOK_routeNOK_no : {report.metadata.tripOK_routeNOK_no}')
+        print(f' tripNOK_routeOK_no : {report.metadata.tripNOK_routeOK_no}')
+        print(f'tripNOK_routeNOK_no : {report.metadata.tripNOK_routeNOK_no}')
+        print(f'tripNOK_NOJP_no     : {report.metadata.tripNOK_NOJP_no}')
+        print()
+        
+        report_path = self.app_config['resource_paths']['gtfs_rt_static_report']
+        report_path = compute_resource_snapshot_path(report_path, fetch_dt)
+        
+        dt_year = fetch_dt.strftime('%Y')
+        dt_month = fetch_dt.strftime('%m')
+        dt_day = fetch_dt.strftime('%d')
+        report_url = f'https://tools.odpch.ch/gtfs-rt-static-compare-report/{dt_year}/{dt_month}/{dt_day}/{report_path.name}';
+        print(f'tripNOK_NOJP_no     : {report_url}')
+        print()
+        
+        print(f'saved to {report_path}')
+        print(header_separator_s)
+        
+        log_message('... DONE')
         
     def _load_gtfs_db(self, gtfs_catalog_item: GTFS_Static_Catalog_Item):
         gtfs_dbs_basepath = Path(self.app_config['resource_paths']['gtfs_db']).parent

--- a/tools/gtfs-rt-static-compare/compare_gtfs_rt_static/models/gtfs_rt_static_report.py
+++ b/tools/gtfs-rt-static-compare/compare_gtfs_rt_static/models/gtfs_rt_static_report.py
@@ -21,6 +21,8 @@ class GTFS_RT_Static_Report_Metadata:
     tripOK_routeNOK_no: int
     tripNOK_routeOK_no: int
     tripNOK_routeNOK_no: int
+    # Trip NOT matched, TripId DOESNT start with ojp:       - should be 0 items
+    tripNOK_NOJP_no: int
     
     @staticmethod
     def from_json(data_json):

--- a/tools/gtfs-rt-static-compare/compare_gtfs_rt_static/models/gtfs_rt_static_report.py
+++ b/tools/gtfs-rt-static-compare/compare_gtfs_rt_static/models/gtfs_rt_static_report.py
@@ -17,9 +17,15 @@ class GTFS_RT_Static_Report_Metadata:
     gtfs_rt_age: int
     
     total_rows_no: int
+    # Trip/Route matched with GTFS
     tripOK_routeOK_no: int
+    
+    # Count Issues
+    # Trip matched / Route not matched against GTFS         - should be 0 items
     tripOK_routeNOK_no: int
+    # Trip NOT matched / Route matched against GTFS         - usually with tripId starts with ojp:
     tripNOK_routeOK_no: int
+    # Trip NOT matched / Route NOT matched against GTFS     - usually with tripId, routeId starts with ojp:
     tripNOK_routeNOK_no: int
     # Trip NOT matched, TripId DOESNT start with ojp:       - should be 0 items
     tripNOK_NOJP_no: int

--- a/tools/gtfs-rt-static-compare/config/config.yml
+++ b/tools/gtfs-rt-static-compare/config/config.yml
@@ -4,7 +4,6 @@ resource_paths:
   gtfs_dbs_json_path: [APP_PATH]/data/gtfs-static-dbs/gtfs-static-dbs.json
   cache_gtfs_db_table: [APP_PATH]/data/gtfs-rt-static-compare-tmp/[GTFS_FILENAME].[TABLE_NAME]-v1.json
   gtfs_rt_static_report: [APP_PATH]/data/gtfs-rt-static-compare-report/[YEAR]/[MONTH]/[DAY]/gtfs_rt_static_report-[YEAR]-[MONTH]-[DAY]-[HHMM].json
-  gtfs_rt_static_mo_report: [APP_PATH]/data/gtfs-rt-static-compare-report/[YEAR]/[MONTH]/gtfs_rt_static_report-[YEAR]-[MONTH].html
   gtfs_rt_static_mo_json: [APP_PATH]/data/gtfs-rt-static-compare-report/[YEAR]/gtfs_rt_static_report-[YEAR]-[MONTH].json
 
 opentransportdata:

--- a/tools/gtfs-rt-static-compare/config/config.yml
+++ b/tools/gtfs-rt-static-compare/config/config.yml
@@ -1,4 +1,5 @@
 resource_paths:
+  app_path: [APP_PATH]
   gtfs_rt_snapshot: [APP_PATH]/data/gtfs-rt-snapshot/[YEAR]/[MONTH]/[DAY]/GTFS_RT-[YEAR]-[MONTH]-[DAY]-[HHMM].json
   gtfs_db: [APP_PATH]/data/gtfs-static-dbs/[GTFS_FILENAME]
   gtfs_dbs_json_path: [APP_PATH]/data/gtfs-static-dbs/gtfs-static-dbs.json


### PR DESCRIPTION
- adds new `GTFS_RT_Static_Report` property `tripNOK_NOJP_no` which tracks the not matched trips that are not `ojp:` prefixed
- adds `cli_batch_compare.py` to process a whole month of GTFS-RT snapshots