### PR TITLE
Optimize gtfs-rt-static-compare

### DIFF
--- a/tools/_shared/inc/helpers/json_helpers.py
+++ b/tools/_shared/inc/helpers/json_helpers.py
@@ -1,5 +1,6 @@
 import os, sys
 import json
+import gzip
 
 from pathlib import Path
 
@@ -21,9 +22,15 @@ def export_json_to_file(json_obj: any, json_path: Path, pretty_print = False):
 def load_json_from_file(json_path: Path):
     if isinstance(json_path, str):
         json_path = Path(json_path)
-
-    json_file = open(json_path, encoding='utf-8')
+    
+    json_file = None
+    if f'{json_path}'[-3:] == '.gz':
+        json_file = gzip.open(json_path)
+    else:
+        json_file = open(json_path, encoding='utf-8')    
+    
     json_obj = json.loads(json_file.read())
-    json_file.close()
 
+    json_file.close()
+    
     return json_obj

--- a/tools/gtfs-rt-static-compare/cli_batch_compare.py
+++ b/tools/gtfs-rt-static-compare/cli_batch_compare.py
@@ -26,7 +26,7 @@ def main():
     gtfs_rt_snapshot_files_path = Path(f'{app_path}/data/gtfs-rt-snapshot')
     
     gtfs_rt_file_paths: List[Path] = []
-    for gtfs_rt_file_path in gtfs_rt_snapshot_files_path.rglob('*.json'):
+    for gtfs_rt_file_path in gtfs_rt_snapshot_files_path.rglob('*.json*'):
         gtfs_rt_file_paths.append(gtfs_rt_file_path)
     gtfs_rt_file_paths.sort()
     

--- a/tools/gtfs-rt-static-compare/compare_gtfs_rt_static/gtfs_controller.py
+++ b/tools/gtfs-rt-static-compare/compare_gtfs_rt_static/gtfs_controller.py
@@ -8,6 +8,9 @@ from typing import Union
 
 from datetime import datetime
 
+import gzip
+import shutil
+
 from .helpers.config_helpers import load_yaml_config
 from .helpers.gtfs_helpers import compute_gtfs_db_filename
 from .helpers.json_helpers import load_json_from_file, export_json_to_file
@@ -110,6 +113,9 @@ class GTFS_Controller:
         
         print(f'... saved to {report_path}')
         print(header_separator_s)
+        
+        print(f'... cleaning up, gzip resource')
+        self._cleanup_resource(gtfs_rt_snapshot_path)
         
         log_message('... DONE')
         
@@ -227,3 +233,14 @@ class GTFS_Controller:
 
         return report_stats
     # _compare_file_gtfs_rt_static
+    
+    # keep a GZIP version of the snapshot
+    def _cleanup_resource(self, resource_path):
+        gzip_path = f'{resource_path}.gz'
+        
+        with open(resource_path, 'rb') as f_in:
+            with gzip.open(gzip_path, 'wb') as f_out:
+                shutil.copyfileobj(f_in, f_out)
+        # with
+        
+        os.remove(resource_path)


### PR DESCRIPTION
- gzip the JSON resources after creating the report
- when reading JSON check if the `.gz` suffix is present and use the gzip handler to read