### PR TITLE
Fix ckan resource downloader

### DIFF
--- a/tools/ckan-utils/inc/ckan_controller.py
+++ b/tools/ckan-utils/inc/ckan_controller.py
@@ -150,7 +150,7 @@ def download_resource(resource_url: str, resource_path: Path):
         os.makedirs(resource_path.parent)
 
     print(f'DOWNLOAD RESOURCE')
-    curl_sh = f'curl {resource_url} -o {resource_path}'
+    curl_sh = f'curl {resource_url} --location -o {resource_path}'
     print(curl_sh, flush=True)
     os.system(curl_sh)
     


### PR DESCRIPTION
- follow-up location redirects