### PR TITLE
Fix `ckan-utils` business-organisations import

### DIFF
--- a/tools/ckan-utils/CHANGELOG.md
+++ b/tools/ckan-utils/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 14.January.2024
 - adds `User-Agent` header to `opentransportdata.swiss` API requests
+- adds `fetch_metadata_cli.py` script that fetches JSON metadata from the CKAN API
 
 23.September.2024
 - use https://opentransportdata.swiss/de/dataset/go-realtime dataset instead of static CSV export

--- a/tools/ckan-utils/README.md
+++ b/tools/ckan-utils/README.md
@@ -1,6 +1,17 @@
 ### CKAN utils for https://opentransportdata.swiss/
 
-## Fetch CKAN resource
+See [./inc/config.yml](./inc/config.yml) for resource defintions
+ 
+
+## Fetch CKAN package metadata
+
+Usage: `fetch_metadata_cli.py [-h] [--package_key PACKAGE_KEY]`
+
+|Param|Description|Example|
+| -- | -- | -- |
+| --package_key| Package key defined in `./inc/config.yml` map_packages | `gtfs_static` |
+
+## Fetch CKAN package resource
 
 Usage: `fetch_package_cli.py [-h] [--package_key PACKAGE_KEY] [--resource_title RESOURCE_TITLE]`
 

--- a/tools/ckan-utils/fetch_metadata_cli.py
+++ b/tools/ckan-utils/fetch_metadata_cli.py
@@ -1,0 +1,42 @@
+import os, sys
+import argparse
+from pathlib import Path
+
+from inc.shared.inc.helpers.config_helpers import load_convenience_config
+from inc.ckan_controller import CKAN_Controller
+
+def main():
+    script_path = Path(os.path.realpath(__file__))
+    app_config = load_convenience_config(script_path)
+
+    usage_help_s = 'fetch_metadata_cli.py [--package_key PACKAGE_KEY]'
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--package_key', '--package_key')
+    args = parser.parse_args()
+
+    package_key = args.package_key
+
+    if not package_key:
+        print(f'Missing --package_key param')
+        print(usage_help_s)
+
+        print('Available package_key items:')
+        for package_key in app_config['map_packages']:
+            package_data = app_config['map_packages'][package_key]
+            alias_s = ''
+            if 'alias' in package_data:
+                alias_s = '(alias ' + package_data['alias'] + ')'
+            print(f'-- {package_key} {alias_s}')
+
+        package_key = input('Type the package_id: ')
+
+    if package_key not in app_config['map_packages']:
+        print(f'package_key {package_key} not found in config.map_packages')
+        sys.exit(1)
+        
+    ckan_controller = CKAN_Controller(app_config)
+    ckan_controller.fetch_metadata(package_key)
+
+if __name__ == "__main__":
+    main()

--- a/tools/ckan-utils/inc/ckan_controller.py
+++ b/tools/ckan-utils/inc/ckan_controller.py
@@ -49,6 +49,21 @@ class CKAN_Controller:
         # end ds_mimetype == 'zip'
 
         log_message(f'CKAN - DONE')
+        
+    def fetch_metadata(self, package_key: str):
+        package_data = self.app_config['map_packages'][package_key]
+        package_id = package_data['package_id']
+        
+        log_message(f'CKAN - FETCH METADATA {package_key}')
+        log_message(f'  PACKAGE_ID      : {package_id}')
+        print()
+        
+        ckan_data = self._fetch_ckan_data(package_key)
+        print('- resources:')
+        for ckan_resource in ckan_data.result.resources:
+            print(f'  - {ckan_resource.identifier}')
+            
+        log_message(f'END')
 
     def _fetch_package_resource(self, package_key: str, filter_resource_title):
         ckan_data = self._fetch_ckan_data(package_key)

--- a/tools/scripts/go-fetch-latest.py
+++ b/tools/scripts/go-fetch-latest.py
@@ -28,7 +28,9 @@ def main():
     print('... DONE')
     
 def _run_package(script_path: Path, app_config: any, package_key: str, resource_prefix: str):
-    _fetch_latest_resource(script_path, package_key)
+    _fetch_metadata(script_path, package_key)
+    _fetch_latest_resource(app_config, script_path, package_key, resource_prefix)
+    
     resource_path = _check_latest_dataset(app_config, package_key, resource_prefix)
     latest_resource_path = app_config['data_paths'][f'{package_key}_latest']
     
@@ -39,28 +41,37 @@ def _run_package(script_path: Path, app_config: any, package_key: str, resource_
     print()
     print(f'=> {latest_resource_path}')
     
-def _fetch_latest_resource(script_path, package_key):
-    # fetch latest archive
-    ckan_fetch_cli_path = f'{script_path.parent}/../ckan-utils/fetch_package_cli.py'
+def _fetch_metadata(script_path, package_key: str):
+    ckan_fetch_cli_path = f'{script_path.parent}/../ckan-utils/fetch_metadata_cli.py'
     ckan_fetch_sh = f'{PYTHON_PATH} {ckan_fetch_cli_path} --package_key {package_key}'
     
     print('')
-    print(f'STEP {package_key}.1 - FETCH LATEST ARCHIVE')
+    print(f'STEP {package_key}.1 - FETCH METADATA')
     print(ckan_fetch_sh, flush=True)
     os.system(ckan_fetch_sh)
-
-def _check_latest_dataset(app_config, package_key, resource_prefix: str):
-    # check latest folder
-    print('')
-    print(f'STEP {package_key}.2 - CHECK LATEST DATASET')
     
+    print()
+    
+def _fetch_latest_resource(app_config: any, script_path: Path, package_key: str, resource_prefix: str):
+    ckan_resource = _compute_resource(app_config, package_key, resource_prefix)
+    
+    # fetch latest archive
+    ckan_fetch_cli_path = f'{script_path.parent}/../ckan-utils/fetch_package_cli.py'
+    ckan_fetch_sh = f'{PYTHON_PATH} {ckan_fetch_cli_path} --package_key {package_key} --resource_title {ckan_resource.identifier}'
+    
+    print(f'STEP {package_key}.2 - FETCH LATEST RESOURCE {ckan_resource.identifier}')
+    print(ckan_fetch_sh, flush=True)
+    os.system(ckan_fetch_sh)
+    
+    print()
+    
+def _compute_resource(app_config, package_key: str, resource_prefix: str):
     ckan_json_path = app_config['resource_paths'][f'ckan_{package_key}_json']
     ckan_json = load_json_from_file(ckan_json_path)
     ckan_data = CKAN_Data.from_ckan_json(ckan_json)
     
     ckan_resource = None
     for ckan_resource_item in ckan_data.result.resources:
-        print(ckan_resource_item.title['en'])
         resource_title: str = ckan_resource_item.title['en']
         if not resource_title.startswith(resource_prefix):
             continue
@@ -72,13 +83,22 @@ def _check_latest_dataset(app_config, package_key, resource_prefix: str):
     if ckan_resource is None:
         print()
         print(row_delimiter_s)
-        print('ERROR - latest resource cant be found')
+        print('ERROR - ckan resource cant be found')
         print()
         print(ckan_data.result.resources)
         print()
         print(row_delimiter_s)
         sys.exit(1)
     #
+    
+    return ckan_resource
+
+def _check_latest_dataset(app_config, package_key: str, resource_prefix: str):
+    # check latest folder
+    print('')
+    print(f'STEP {package_key}.3 - CHECK LATEST DATASET')
+    
+    ckan_resource = _compute_resource(app_config, package_key, resource_prefix)
     
     ds_mimetype: str = ckan_resource.mimetype
     ds_mimetype = ds_mimetype.lower().strip()


### PR DESCRIPTION
- adds `./ckan-utils/fetch_metadata_cli.py` script that fetches JSON metadata from the CKAN API
- updates `./scripts/go-fetch-latest.py` to fetch the specific resource