### PR TITLE
Extend ckan-utils tool

### DIFF
--- a/tools/_shared/inc/models/ckan_data.py
+++ b/tools/_shared/inc/models/ckan_data.py
@@ -1,6 +1,8 @@
 import os
 import sys
 
+from pathlib import Path
+
 from dataclasses import dataclass, asdict
 from typing import List, Dict, Optional
 
@@ -12,6 +14,9 @@ class CKAN_Resource:
     url: str
     created_s: str
     modified_s: str
+    
+    filename: str
+    extension: str
 
     def __init__(self, **kwargs):
         # do this way otherwise we get a linter error
@@ -20,6 +25,10 @@ class CKAN_Resource:
         for field_name, field_metadata in dataclass_fields.items():
             value = kwargs.get(field_name, field_metadata.default)
             self.set_field(field_name, value, kwargs)
+        
+        res_filename = CKAN_Resource._compute_filename(kwargs['url'])
+        self.filename = res_filename
+        self.extension = CKAN_Resource._compute_extension(res_filename)
             
     def set_field(self, field_name, value, kwargs):
         if field_name == 'created_s':
@@ -28,6 +37,17 @@ class CKAN_Resource:
             value = kwargs.get('modified', None)
 
         setattr(self, field_name, value)
+    
+    @staticmethod
+    def _compute_filename(res_url: str):
+        res_filename = res_url.split('/')[-1]
+        return res_filename
+    
+    @staticmethod
+    def _compute_extension(res_filename: str):
+        res_extension = Path(res_filename).suffix.lower()
+        return res_extension
+        
         
 @dataclass
 class CKAN_Result:

--- a/tools/ckan-utils/CHANGELOG.md
+++ b/tools/ckan-utils/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG ckan-utils
 
+17.January.2024
+- make import more robust, rely on `package_id` of the datasets
+- use Python standard libs for fetching data and unzipping resources
+- dont rely on resource `mimetype`, check the `url` instead
+
 14.January.2024
 - adds `User-Agent` header to `opentransportdata.swiss` API requests
 - adds `fetch_metadata_cli.py` script that fetches JSON metadata from the CKAN API

--- a/tools/ckan-utils/README.md
+++ b/tools/ckan-utils/README.md
@@ -1,21 +1,21 @@
 ### CKAN utils for https://opentransportdata.swiss/
 
-See [./inc/config.yml](./inc/config.yml) for resource defintions
- 
+See [./inc/config.yml](./inc/config.yml) for resource paths
+`PACKAGE_ID` param comes from https://data.opentransportdata.swiss/en/organization/oevch
 
 ## Fetch CKAN package metadata
 
-Usage: `fetch_metadata_cli.py [-h] [--package_key PACKAGE_KEY]`
+Usage: `fetch_metadata_cli.py [-h] [--package_id PACKAGE_ID]`
 
 |Param|Description|Example|
 | -- | -- | -- |
-| --package_key| Package key defined in `./inc/config.yml` map_packages | `gtfs_static` |
+| --package_id| package_id from https://data.opentransportdata.swiss/en/organization/oevch | `timetable-54-2025-hrdf` |
 
 ## Fetch CKAN package resource
 
-Usage: `fetch_package_cli.py [-h] [--package_key PACKAGE_KEY] [--resource_title RESOURCE_TITLE]`
+Usage: `fetch_package_cli.py [-h] [--package_key PACKAGE_ID] [--resource_title RESOURCE_TITLE]`
 
 |Param|Description|Example|
 | -- | -- | -- |
-| --package_key| Package key defined in `./inc/config.yml` map_packages | `gtfs_static` |
+| --package_id| package_id from https://data.opentransportdata.swiss/en/organization/oevch | `timetable-54-2025-hrdf` |
 | --resource_title | If present, the script will try to fetch fetch the resource named with this title. If missing, the script will fetch the first resource in the list (last updated) | `OeV_Sammlung_CH_HRDF_5_40_41_2022_20220513_211738.zip` or `None` |

--- a/tools/ckan-utils/fetch_metadata_cli.py
+++ b/tools/ckan-utils/fetch_metadata_cli.py
@@ -9,34 +9,22 @@ def main():
     script_path = Path(os.path.realpath(__file__))
     app_config = load_convenience_config(script_path)
 
-    usage_help_s = 'fetch_metadata_cli.py [--package_key PACKAGE_KEY]'
+    usage_help_s = 'fetch_metadata_cli.py [--package_id package_id]'
 
     parser = argparse.ArgumentParser()
-    parser.add_argument('--package_key', '--package_key')
+    parser.add_argument('--package_id', '--package_id')
     args = parser.parse_args()
 
-    package_key = args.package_key
+    package_id = args.package_id
 
-    if not package_key:
-        print(f'Missing --package_key param')
+    if not package_id:
+        print(f'Missing --package_id param')
         print(usage_help_s)
 
-        print('Available package_key items:')
-        for package_key in app_config['map_packages']:
-            package_data = app_config['map_packages'][package_key]
-            alias_s = ''
-            if 'alias' in package_data:
-                alias_s = '(alias ' + package_data['alias'] + ')'
-            print(f'-- {package_key} {alias_s}')
-
-        package_key = input('Type the package_id: ')
-
-    if package_key not in app_config['map_packages']:
-        print(f'package_key {package_key} not found in config.map_packages')
         sys.exit(1)
         
     ckan_controller = CKAN_Controller(app_config)
-    ckan_controller.fetch_metadata(package_key)
+    ckan_controller.fetch_metadata(package_id)
 
 if __name__ == "__main__":
     main()

--- a/tools/ckan-utils/fetch_package_cli.py
+++ b/tools/ckan-utils/fetch_package_cli.py
@@ -9,37 +9,25 @@ def main():
     script_path = Path(os.path.realpath(__file__))
     app_config = load_convenience_config(script_path)
 
-    usage_help_s = 'fetch_latest_package_cli.py [--package_key PACKAGE_KEY] [--resource_title RESOURCE_TITLE]'
+    usage_help_s = 'fetch_latest_package_cli.py [--package_id package_id] [--resource_title RESOURCE_TITLE]'
 
     parser = argparse.ArgumentParser()
-    parser.add_argument('--package_key', '--package_key')
+    parser.add_argument('--package_id', '--package_id')
     parser.add_argument('--resource_title', '--resource_title')
     args = parser.parse_args()
 
-    package_key = args.package_key
+    package_id = args.package_id
 
-    if not package_key:
-        print(f'Missing --package_key param')
+    if not package_id:
+        print(f'Missing --package_id param')
         print(usage_help_s)
 
-        print('Available package_key items:')
-        for package_key in app_config['map_packages']:
-            package_data = app_config['map_packages'][package_key]
-            alias_s = ''
-            if 'alias' in package_data:
-                alias_s = '(alias ' + package_data['alias'] + ')'
-            print(f'-- {package_key} {alias_s}')
-
-        package_key = input('Type the package_id: ')
-
-    if package_key not in app_config['map_packages']:
-        print(f'package_key {package_key} not found in config.map_packages')
         sys.exit(1)
 
     resource_title = args.resource_title or None
 
     ckan_controller = CKAN_Controller(app_config)
-    ckan_controller.fetch_latest(package_key, resource_title)
+    ckan_controller.fetch_latest(package_id, resource_title)
 
 if __name__ == "__main__":
     main()

--- a/tools/ckan-utils/inc/ckan_controller.py
+++ b/tools/ckan-utils/inc/ckan_controller.py
@@ -17,59 +17,55 @@ class CKAN_Controller:
     def __init__(self, app_config):
         self.app_config = app_config
 
-    def fetch_latest(self, package_key: str, resource_title):
-        package_data = self.app_config['map_packages'][package_key]
-        package_id = package_data['package_id']
-
-        log_message(f'CKAN - FETCH PACKAGE {package_key}')
+    def fetch_latest(self, package_id: str, resource_title):
+        log_message(f'CKAN - FETCH PACKAGE {package_id}')
         log_message(f'  PACKAGE_ID      : {package_id}')
         log_message(f'  RESOURCE_TITLE  : {resource_title}')
 
-        ds_resource = self._fetch_package_resource(package_key, resource_title)
-        ds_filename = ds_resource.title['en']
+        ds_resource = self._fetch_package_resource(package_id, resource_title)
+        ds_res_filename = ds_resource.url.split('/')[-1]
 
-        package_data = self.app_config['map_packages'][package_key]
+        package_base_path_s: str = self.app_config['resource_paths']['package_base_path']
+        package_base_path_s = package_base_path_s.replace('[PACKAGE_ID]', package_id)
+        package_base_path = Path(package_base_path_s)
         
-        ds_resource_path = Path(package_data['base_path'] + '/' + ds_filename)
-        if os.path.isfile(ds_resource_path):
-            print('')
-            log_message(f'... resource already downloaded at path {ds_resource_path}')
-        else:
+        ds_resource_path = Path(f'{package_base_path}/{ds_res_filename}')
+        if not os.path.isfile(ds_resource_path):
             ds_url = ds_resource.url
             download_resource(ds_url, ds_resource_path)
-            
-        ds_mimetype: str = ds_resource.mimetype
-        ds_mimetype = ds_mimetype.lower().strip()
+        #
         
-        if 'zip' in ds_mimetype:
-            ds_folder = ds_filename[0:-4]
-            ds_folder_path = Path(package_data['base_path'] + '/' + ds_folder)
-            if os.path.isdir(ds_folder_path):
-                print('')
-                log_message(f'... resource already unzipped at path {ds_folder_path}')
-            else:
-                run_unzip(ds_resource_path, ds_folder_path)
+        print()
+        log_message(f'... downloaded to {ds_resource_path}')
+            
+        ds_res_extension = Path(ds_res_filename.lower()).suffix
+        if ds_res_extension == '.zip':
+            ds_zip_folder = ds_res_filename[0:-4]
+            ds_zip_folder_path = Path(f'{package_base_path}/{ds_zip_folder}')
+            if not os.path.isdir(ds_zip_folder_path):
+                run_unzip(ds_resource_path, ds_zip_folder_path)
+                
+            print()
+            log_message(f'... extracted to {ds_zip_folder_path}')
         # end ds_mimetype == 'zip'
-
+        
+        print()
         log_message(f'CKAN - DONE')
         
-    def fetch_metadata(self, package_key: str):
-        package_data = self.app_config['map_packages'][package_key]
-        package_id = package_data['package_id']
-        
-        log_message(f'CKAN - FETCH METADATA {package_key}')
+    def fetch_metadata(self, package_id: str):
+        log_message(f'CKAN - FETCH METADATA')
         log_message(f'  PACKAGE_ID      : {package_id}')
         print()
         
-        ckan_data = self._fetch_ckan_data(package_key)
+        ckan_data = self._fetch_ckan_metadata(package_id)
         print('- resources:')
         for ckan_resource in ckan_data.result.resources:
-            print(f'  - {ckan_resource.identifier}')
+            print(f'  - {ckan_resource.identifier} -> {ckan_resource.url}')
             
         log_message(f'END')
 
-    def _fetch_package_resource(self, package_key: str, filter_resource_title):
-        ckan_data = self._fetch_ckan_data(package_key)
+    def _fetch_package_resource(self, package_id: str, filter_resource_title):
+        ckan_data = self._fetch_ckan_metadata(package_id)
         
         if filter_resource_title is None:
             return ckan_data.result.resources[0]
@@ -102,26 +98,23 @@ class CKAN_Controller:
         # loop resources
         
         sys.exit(1)
+        
+    def _fetch_ckan_metadata(self, package_id):
+        ckan_json_path: str = f"{self.app_config['resource_paths']['ckan_metadata_path']}"
+        ckan_json_path = ckan_json_path.replace('[PACKAGE_ID]', package_id)
 
-    def _fetch_ckan_data(self, package_key):
-        package_data_json_path = f"{self.app_config['package_cache']['local_path']}"
-        package_data_json_path = package_data_json_path.replace('[PACKAGE_KEY]', package_key)
-
-        if os.path.isfile(package_data_json_path):
+        if os.path.isfile(ckan_json_path):
             package_data_json_ttl = self.app_config['package_cache']['ttl']
-            package_data_json_ts = os.path.getmtime(package_data_json_path)
+            package_data_json_ts = os.path.getmtime(ckan_json_path)
             now_ts = time.time()
             cache_age = now_ts - package_data_json_ts
             is_fresh = cache_age < package_data_json_ttl
             if is_fresh:
-                log_message(f'... load package JSON from {package_data_json_path}')
-                package_data_json = load_json_from_file(package_data_json_path)
+                log_message(f'... load package JSON from {ckan_json_path}')
+                package_data_json = load_json_from_file(ckan_json_path)
                 ckan_data = CKAN_Data.from_ckan_json(package_data_json)
                 return ckan_data
-
-        package_data = self.app_config['map_packages'][package_key]
-        package_id = package_data['package_id']
-
+            
         ckan_api_url = f"{self.app_config['ckan_data']['package_show_url_template']}"
         ckan_api_url = ckan_api_url.replace('[PACKAGE_ID]', package_id)
             
@@ -130,7 +123,7 @@ class CKAN_Controller:
         log_message(f'... fetching package JSON from {ckan_api_url}')
 
         package_data_json = fetch_latest_ckan_json(ckan_api_url, ckan_api_authorization)
-        export_json_to_file(package_data_json, package_data_json_path, pretty_print=True)
+        export_json_to_file(package_data_json, ckan_json_path, pretty_print=True)
         
         ckan_data = CKAN_Data.from_ckan_json(package_data_json)
 

--- a/tools/ckan-utils/inc/ckan_controller.py
+++ b/tools/ckan-utils/inc/ckan_controller.py
@@ -5,6 +5,8 @@ import time
 from pathlib import Path
 
 import zipfile
+import requests
+
 from .shared.inc.helpers.json_helpers import export_json_to_file, load_json_from_file
 from .shared.inc.helpers.log_helpers import log_message
 
@@ -167,10 +169,14 @@ def download_resource(resource_url: str, resource_path: Path):
     if not os.path.isdir(resource_path.parent):
         os.makedirs(resource_path.parent)
 
+    response = requests.get(resource_url, timeout=30, stream=True)
+    response.raise_for_status()
+    
     print(f'DOWNLOAD RESOURCE')
-    curl_sh = f'curl {resource_url} --location -H "User-Agent: {USER_AGENT}" -o {resource_path}'
-    print(curl_sh, flush=True)
-    os.system(curl_sh)
+    res_file = open(resource_path, 'wb')
+    for file_chunk in response.iter_content(chunk_size=65536):
+        res_file.write(file_chunk)
+    res_file.close()
     
     print(f'... DONE')
     print('')

--- a/tools/ckan-utils/inc/ckan_controller.py
+++ b/tools/ckan-utils/inc/ckan_controller.py
@@ -68,14 +68,13 @@ class CKAN_Controller:
         ckan_data = self._fetch_ckan_metadata(package_id)
         
         if filter_resource_title is None:
+            # return latest resource if filter_resource_title is missing
             return ckan_data.result.resources[0]
         
         filter_resource_title = filter_resource_title.strip().lower()
         
         for ds_resource in ckan_data.result.resources:
-            resource_title = ds_resource.title['en'].strip().lower()
-
-            if resource_title[0:-4] == filter_resource_title[0:-4]:
+            if ds_resource.filename.lower() == filter_resource_title:
                 return ds_resource
             
         row_delimiter_s = '='*70
@@ -88,13 +87,13 @@ class CKAN_Controller:
         print(row_delimiter_s)
 
         for ds_resource in ckan_data.result.resources:
-            resource_title: str = ds_resource.title['en'].strip().lower()
+            resource_filename: str = ds_resource.filename
             
             last_modified_day = ds_resource.modified_s[0:10]
             last_modified_hh_mm = ds_resource.modified_s[11:16]
             last_modified_s = f'{last_modified_day} {last_modified_hh_mm}'
 
-            print(f'-- {resource_title.ljust(40)} - {last_modified_s}')
+            print(f'-- {resource_filename.ljust(40)} - {last_modified_s}')
         # loop resources
         
         sys.exit(1)

--- a/tools/ckan-utils/inc/ckan_controller.py
+++ b/tools/ckan-utils/inc/ckan_controller.py
@@ -4,6 +4,7 @@ import urllib.request
 import time
 from pathlib import Path
 
+import zipfile
 from .shared.inc.helpers.json_helpers import export_json_to_file, load_json_from_file
 from .shared.inc.helpers.log_helpers import log_message
 
@@ -152,11 +153,10 @@ def fetch_latest_ckan_json(ckan_api_url, ckan_api_authorization):
 
 def run_unzip(archive_path: Path, folder_path: Path):
     log_message('RUN UNZIP')
-
-    unzip_sh = f'unzip {archive_path} -d {folder_path}'
-    print(unzip_sh, flush=True)
-    os.system(unzip_sh)
-
+    
+    with zipfile.ZipFile(archive_path, 'r') as zip_ref:
+        zip_ref.extractall(folder_path)
+                    
     print(f'... DONE')
     print('')
 

--- a/tools/ckan-utils/inc/config.yml
+++ b/tools/ckan-utils/inc/config.yml
@@ -2,23 +2,9 @@ ckan_data:
   authorization: 57c5dbbbf1fe4d000100001842c323fa9ff44fbba0b9b925f0c052d1
   package_show_url_template: https://api.opentransportdata.swiss/ckan-api/package_show?id=[PACKAGE_ID]
 
-map_packages:
-  hrdf_5_4: &hrdf_5_4
-    package_id: timetable-54-2025-hrdf
-    base_path: [APP_PATH]/data/opentransportdata.swiss/hrdf
-  gtfs_static: 
-    package_id: timetable-2025-gtfs2020
-    base_path: [APP_PATH]/data/opentransportdata.swiss/gtfs-static
-  hrdf:
-    <<: *hrdf_5_4
-    alias: hrdf_5_4
-  go:
-    package_id: business-organisations
-    base_path: [APP_PATH]/data/opentransportdata.swiss/business-organisations
-  go-realtime:
-    package_id: go-realtime
-    base_path: [APP_PATH]/data/opentransportdata.swiss/go-realtime
+resource_paths:
+  ckan_metadata_path: [APP_PATH]/tmp/ckan_[PACKAGE_ID].json
+  package_base_path: [APP_PATH]/data/opentransportdata.swiss/[PACKAGE_ID]
 
 package_cache:
-  local_path: [APP_PATH]/tmp/ckan_[PACKAGE_KEY].json
   ttl: 300

--- a/tools/gtfs-static-db-importer/cli_aggregate_dbs.py
+++ b/tools/gtfs-static-db-importer/cli_aggregate_dbs.py
@@ -5,7 +5,7 @@ from pathlib import Path
 from typing import Dict, List
 from datetime import datetime
 
-from inc.shared.inc.helpers.config_helpers import load_convenience_config
+from inc.shared.inc.helpers.config_helpers import load_convenience_config, load_yaml_config
 from inc.shared.inc.models.gtfs_static_db_catalog import GTFS_Static_Catalog_Report, GTFS_Static_Catalog_Item
 from inc.shared.inc.models.ckan_data import CKAN_Data, CKAN_Resource
 from inc.shared.inc.helpers.json_helpers import export_json_to_file, load_json_from_file
@@ -46,7 +46,12 @@ def _scan_local_dbs(app_config: any) -> Dict[str, Path]:
     return map_local_dbs
 
 def _load_ckan_data(app_config: any) -> List[CKAN_Resource]:
-    gtfs_ckan_json_path = app_config['gtfs_ckan_json_path']
+    scripts_config_path = app_config['other_config_paths']['scripts_config']
+    scripts_config = load_yaml_config(scripts_config_path)
+    gtfs_package_id = scripts_config['current_package_ids']['gtfs']
+    
+    gtfs_ckan_json_path: str = app_config['gtfs_ckan_json_path']
+    gtfs_ckan_json_path = gtfs_ckan_json_path.replace('[PACKAGE_ID]', gtfs_package_id)
     gtfs_ckan_json = load_json_from_file(gtfs_ckan_json_path)
     gtfs_ckan = CKAN_Data.from_ckan_json(gtfs_ckan_json)
     

--- a/tools/gtfs-static-db-importer/inc/config.yml
+++ b/tools/gtfs-static-db-importer/inc/config.yml
@@ -3,8 +3,11 @@ map_sql_queries:
   select_stop_times_group_by: [APP_PATH]/inc/sql/select_trips_group_by_stop_times.sql
   update_stop_times_reset: [APP_PATH]/inc/sql/update_stop_times_reset.sql
 
+other_config_paths:
+  scripts_config: [APP_PATH]/inc/config/scripts-config.yml
+
 gtfs_dbs_base_path: [APP_PATH]/data/gtfs-static-dbs
-gtfs_ckan_json_path: [APP_PATH]/data/ckan-utils-tmp/ckan_gtfs_static.json
+gtfs_ckan_json_path: [APP_PATH]/data/ckan-utils-tmp/ckan_[PACKAGE_ID].json
 gtfs_dbs_json_path: [APP_PATH]/data/gtfs-static-dbs/gtfs-static-dbs.json
 
 gtfs_rt_updates:

--- a/tools/gtfs-static-db-importer/inc/config/scripts-config.yml
+++ b/tools/gtfs-static-db-importer/inc/config/scripts-config.yml
@@ -1,0 +1,1 @@
+../../../scripts/inc/config.yml

--- a/tools/hrdf-check-duplicates/inc/hrdf_consolidated_duplicates_report.py
+++ b/tools/hrdf-check-duplicates/inc/hrdf_consolidated_duplicates_report.py
@@ -66,14 +66,12 @@ class HRDF_Consolidated_Duplicates_Report:
                     map_data[agency_id][hrdf_day].append(report_row)
             # agency_data
 
-        # hrdf_day
+        # loop hrdf_day
 
+        # filter_agency_ids = ['11']
         filter_agency_ids = []
-        filter_agency_ids = ['11']
-        self.compute_consolidated_report_for_agency(map_data, filter_agency_ids)
         
-        # all
-        self.compute_consolidated_report_for_agency(map_data, [])
+        self.compute_consolidated_report_for_agency(map_data, filter_agency_ids)
 
     def compute_consolidated_report_for_agency(self, map_data, agency_ids):
         csv_path = f'{self.consolidate_hrdf_duplicates_report_path_template}'

--- a/tools/hrdf-check-duplicates/inc/hrdf_consolidated_duplicates_report.py
+++ b/tools/hrdf-check-duplicates/inc/hrdf_consolidated_duplicates_report.py
@@ -2,6 +2,8 @@ import os, sys
 import time
 import json
 
+from datetime import datetime
+
 import urllib.request
 
 from .shared.inc.helpers.log_helpers import log_message
@@ -18,11 +20,18 @@ class HRDF_Consolidated_Duplicates_Report:
 
     def compute_consolidated_report(self):
         duplicates_list_json = self.fetch_report_duplicates_list()
+        
+        report_year = datetime.now().year
+        last_year = report_year - 1
 
         map_data = {}
         
         hrdf_days = duplicates_list_json['hrdf_duplicates_available_days']
         for (idx, hrdf_day) in enumerate(hrdf_days):
+            hrdf_day_year = int(hrdf_day[0:4])
+            if hrdf_day_year < last_year:
+                continue
+            
             duplicates_report_path: str = f'{self.duplicates_report_path_template}'
             duplicates_report_path = duplicates_report_path.replace('[HRDF_YMD]', hrdf_day)
 

--- a/tools/hrdf-db-importer/cli_aggregate_dbs.py
+++ b/tools/hrdf-db-importer/cli_aggregate_dbs.py
@@ -5,7 +5,7 @@ from pathlib import Path
 from typing import Dict, List
 from datetime import datetime
 
-from inc.HRDF_Parser.shared.inc.helpers.config_helpers import load_convenience_config
+from inc.HRDF_Parser.shared.inc.helpers.config_helpers import load_convenience_config, load_yaml_config
 from inc.HRDF_Parser.shared.inc.models.ckan_data import CKAN_Data, CKAN_Resource
 from inc.HRDF_Parser.shared.inc.models.hrdf_db_catalog import HRDF_Catalog_Report, HRDF_Catalog_Item, HRDF_Catalog_Metadata
 from inc.HRDF_Parser.shared.inc.helpers.gtfs_helpers import compute_date_from_gtfs_db_filename
@@ -49,7 +49,12 @@ def _scan_local_dbs(app_config: any) -> Dict[str, Path]:
     return map_local_dbs
 
 def _load_ckan_data(app_config: any) -> List[CKAN_Resource]:
-    ckan_json_path = app_config['hrdf_ckan_json_path']
+    scripts_config_path = app_config['other_configs']['scripts_config_path']
+    scripts_config = load_yaml_config(scripts_config_path)
+    hrdf_package_id = scripts_config['current_package_ids']['hrdf']
+    
+    ckan_json_path: str = app_config['hrdf_ckan_json_path']
+    ckan_json_path = ckan_json_path.replace('[PACKAGE_ID]', hrdf_package_id)
     ckan_json = load_json_from_file(ckan_json_path)
     hrdf_ckan = CKAN_Data.from_ckan_json(ckan_json)
     

--- a/tools/hrdf-db-importer/inc/config.yml
+++ b/tools/hrdf-db-importer/inc/config.yml
@@ -1,5 +1,6 @@
 other_configs:
   schema_config_path: [APP_PATH]/inc/hrdf_schema.yml
+  scripts_config_path: [APP_PATH]/inc/config/scripts-config.yml
 
 map_sql_queries:
   fplan_join_trip_bitfeld: [APP_PATH]/inc/HRDF_Parser/shared/inc/sql/hrdf/fplan_join_trip_bitfeld.sql
@@ -9,7 +10,7 @@ hrdf_default_service_id: "000017" # All days
 
 hrdf_dbs_base_path: [APP_PATH]/data/hrdf-dbs
 hrdf_db_schema_path: "[APP_PATH]/inc/hrdf_schema.yml"
-hrdf_ckan_json_path: [APP_PATH]/data/ckan-utils-tmp/ckan_hrdf_5_4.json
+hrdf_ckan_json_path: [APP_PATH]/data/ckan-utils-tmp/ckan_[PACKAGE_ID].json
 hrdf_dbs_json_path: [APP_PATH]/data/hrdf-dbs/hrdf-dbs.json
 
 # See 7.5.1 in HRDF realisation guide

--- a/tools/hrdf-db-importer/inc/config/scripts-config.yml
+++ b/tools/hrdf-db-importer/inc/config/scripts-config.yml
@@ -1,0 +1,1 @@
+../../../scripts/inc/config.yml

--- a/tools/scripts/cli_opentransportdata_csv_fetch_latest.py
+++ b/tools/scripts/cli_opentransportdata_csv_fetch_latest.py
@@ -9,8 +9,6 @@ from inc.shared.inc.models.ckan_data import CKAN_Data
 
 from inc.common import PYTHON_PATH, ROW_DELIMITER_S, compute_ckan_resource_by_prefix, compute_ckan_data
 
-# go-fetch-latest.py - rename to cli_opentransportdata_csv_fetch_latest.py
-
 def main():
     script_path = Path(os.path.realpath(__file__))
     app_config = load_convenience_config(script_path)

--- a/tools/scripts/go-fetch-latest.py
+++ b/tools/scripts/go-fetch-latest.py
@@ -7,127 +7,111 @@ from inc.shared.inc.helpers.json_helpers import load_json_from_file
 from inc.shared.inc.helpers.gtfs_helpers import compute_gtfs_day_from_resource_path, compute_gtfs_db_filename
 from inc.shared.inc.models.ckan_data import CKAN_Data
 
-PYTHON_PATH = sys.executable
-row_delimiter_s = '='*70
+from inc.common import PYTHON_PATH, ROW_DELIMITER_S, compute_ckan_resource_by_prefix, compute_ckan_data
+
+# go-fetch-latest.py - rename to cli_opentransportdata_csv_fetch_latest.py
 
 def main():
     script_path = Path(os.path.realpath(__file__))
     app_config = load_convenience_config(script_path)
     
-    print('START ./tools/scripts/go-fetch-latest.py')
+    print('START ./tools/scripts/cli_opentransportdata_csv_fetch_latest.py')
     print()
     print('Resources:')
-    print('  - https://opentransportdata.swiss/en/dataset/business-organisations')
-    print('  - https://opentransportdata.swiss/en/dataset/go-realtime')
+    print('  - https://data.opentransportdata.swiss/en/dataset/business-organisations')
+    print('  - https://data.opentransportdata.swiss/en/dataset/go-realtime')
+    print('  - https://data.opentransportdata.swiss/en/dataset/slnid-line')
     print()
-
-    _run_package(script_path, app_config, 'go', 'actual_date_business_organisation')
-    _run_package(script_path, app_config, 'go-realtime', 'business_organisation_realtime')
+    
+    for package_id in app_config['csv_latest_data']:
+        _run_package(script_path, app_config, package_id)
+        print()
+    #
     
     print()
     print('... DONE')
     
-def _run_package(script_path: Path, app_config: any, package_key: str, resource_prefix: str):
-    _fetch_metadata(script_path, package_key)
-    _fetch_latest_resource(app_config, script_path, package_key, resource_prefix)
+def _run_package(script_path: Path, app_config: any, package_id: str):
+    _fetch_metadata(script_path, package_id)
+    _fetch_resource(script_path, app_config, package_id)
+    _symlink_latest_resource(app_config, package_id)
     
-    resource_path = _check_latest_dataset(app_config, package_key, resource_prefix)
-    latest_resource_path = app_config['data_paths'][f'{package_key}_latest']
-    
-    if os.path.islink(latest_resource_path):
-        os.remove(latest_resource_path)
-    os.symlink(resource_path, latest_resource_path)
-    
-    print()
-    print(f'=> {latest_resource_path}')
-    
-def _fetch_metadata(script_path, package_key: str):
+def _fetch_metadata(script_path, package_id: str):
     ckan_fetch_cli_path = f'{script_path.parent}/../ckan-utils/fetch_metadata_cli.py'
-    ckan_fetch_sh = f'{PYTHON_PATH} {ckan_fetch_cli_path} --package_key {package_key}'
+    ckan_fetch_sh = f'{PYTHON_PATH} {ckan_fetch_cli_path} --package_id {package_id}'
     
     print('')
-    print(f'STEP {package_key}.1 - FETCH METADATA')
+    print(f'STEP {package_id}.1 - FETCH METADATA')
     print(ckan_fetch_sh, flush=True)
     os.system(ckan_fetch_sh)
     
     print()
     
-def _fetch_latest_resource(app_config: any, script_path: Path, package_key: str, resource_prefix: str):
-    ckan_resource = _compute_resource(app_config, package_key, resource_prefix)
+def _fetch_resource(script_path: Path, app_config, package_id: str):
+    file_prefix = app_config['csv_latest_data'][package_id].get('file_prefix', None)
+    if file_prefix is None:
+        _fetch_latest_resource(script_path, package_id)
+    else:
+        _fetch_resource_by_prefix(app_config, script_path, package_id, file_prefix)
+    #
+
+def _fetch_latest_resource(script_path: Path, package_id: str):
+    # fetch latest archive
+    ckan_fetch_cli_path = f'{script_path.parent}/../ckan-utils/fetch_package_cli.py'
+    ckan_fetch_sh = f'{PYTHON_PATH} {ckan_fetch_cli_path} --package_id {package_id}'
+    
+    print(f'STEP {package_id}.2 - FETCH LATEST RESOURCE')
+    print(ckan_fetch_sh, flush=True)
+    os.system(ckan_fetch_sh)
+    
+def _fetch_resource_by_prefix(app_config: any, script_path: Path, package_id: str, resource_prefix: str):
+    ckan_resource = compute_ckan_resource_by_prefix(app_config, package_id, resource_prefix)
     
     # fetch latest archive
     ckan_fetch_cli_path = f'{script_path.parent}/../ckan-utils/fetch_package_cli.py'
-    ckan_fetch_sh = f'{PYTHON_PATH} {ckan_fetch_cli_path} --package_key {package_key} --resource_title {ckan_resource.identifier}'
+    ckan_fetch_sh = f'{PYTHON_PATH} {ckan_fetch_cli_path} --package_id {package_id} --resource_title {ckan_resource.identifier}'
     
-    print(f'STEP {package_key}.2 - FETCH LATEST RESOURCE {ckan_resource.identifier}')
+    print(f'STEP {package_id}.2 - FETCH RESOURCE by PREFIX {ckan_resource.identifier}')
     print(ckan_fetch_sh, flush=True)
     os.system(ckan_fetch_sh)
-    
-    print()
-    
-def _compute_resource(app_config, package_key: str, resource_prefix: str):
-    ckan_json_path = app_config['resource_paths'][f'ckan_{package_key}_json']
-    ckan_json = load_json_from_file(ckan_json_path)
-    ckan_data = CKAN_Data.from_ckan_json(ckan_json)
-    
-    ckan_resource = None
-    for ckan_resource_item in ckan_data.result.resources:
-        resource_title: str = ckan_resource_item.title['en']
-        if not resource_title.startswith(resource_prefix):
-            continue
-        
-        ckan_resource = ckan_resource_item
-        break
-    # loop resources
-    
-    if ckan_resource is None:
-        print()
-        print(row_delimiter_s)
-        print('ERROR - ckan resource cant be found')
-        print()
-        print(ckan_data.result.resources)
-        print()
-        print(row_delimiter_s)
-        sys.exit(1)
-    #
-    
-    return ckan_resource
 
-def _check_latest_dataset(app_config, package_key: str, resource_prefix: str):
-    # check latest folder
-    print('')
-    print(f'STEP {package_key}.3 - CHECK LATEST DATASET')
+    print()
+
+def _symlink_latest_resource(app_config, package_id: str):
+    symlink_latest_path_s: str = app_config['csv_latest_data'][package_id].get('symlink_latest_path', None)
+    if symlink_latest_path_s is None:
+        return
     
-    ckan_resource = _compute_resource(app_config, package_key, resource_prefix)
+    print(f'STEP {package_id}.3 - SYMLINK LATEST DATASET')
     
-    ds_mimetype: str = ckan_resource.mimetype
-    ds_mimetype = ds_mimetype.lower().strip()
+    package_base_path: str = app_config['data_paths']['opentransportdata']['package_base_path']
+    package_base_path = package_base_path.replace('[PACKAGE_ID]', package_id)
     
-    resource_name = ckan_resource.title['en']
-    resources_base_folder_path = app_config['data_paths'][f'{package_key}_data']
+    resource_prefix = app_config['csv_latest_data'][package_id]['file_prefix'] or None
+    ds_resource = compute_ckan_resource_by_prefix(app_config, package_id, resource_prefix)
     
-    if 'zip' in ds_mimetype:
-        # the actual name is without .zip extension
-        resource_name = resource_name[0:-4]
-        # same for the folder that contains the resource
-        resource_folder_name = resource_name
-        
-        resource_path = Path(f'{resources_base_folder_path}/{resource_folder_name}/{resource_name}')
-    else:
-        resource_path = Path(f'{resources_base_folder_path}/{resource_name}')
-    # end ds_mimetype == 'zip'
+    ds_res_filename = ds_resource.url.split('/')[-1]
+    ds_res_extension = Path(ds_res_filename.lower()).suffix
     
-    if not os.path.isfile(resource_path):
-        print()
-        print(row_delimiter_s)
-        print('ERROR - latest resource not found at path')
-        print(resource_path)
-        print(row_delimiter_s)
-        sys.exit(1)
-        
-    print(f'... use following resource: {resource_path}')
-        
-    return resource_path
+    ds_res_path = Path(f'{package_base_path}/{ds_res_filename}')
+    if ds_res_extension == '.zip':
+        ds_res_zip_folder = ds_res_filename[0:-4]
+        ds_res_path = Path(f'{package_base_path}/{ds_res_zip_folder}/{ds_res_zip_folder}')
+    # else:
+    
+    symlink_latest_path_s = symlink_latest_path_s.replace('[PACKAGE_ID]', package_id)
+    file_prefix = app_config['csv_latest_data'][package_id]['file_prefix']
+    symlink_latest_path_s = symlink_latest_path_s.replace('[PREFIX]', file_prefix)
+    
+    symlink_latest_path = Path(symlink_latest_path_s)
+    
+    if os.path.islink(symlink_latest_path):
+        os.remove(symlink_latest_path)
+    os.symlink(ds_res_path, symlink_latest_path)
+
+    print()
+    print(f'=> {symlink_latest_path}')
+    print()
 
 if __name__ == "__main__":
     main()

--- a/tools/scripts/gtfs-compute-latest.py
+++ b/tools/scripts/gtfs-compute-latest.py
@@ -7,65 +7,26 @@ from inc.shared.inc.helpers.json_helpers import load_json_from_file
 from inc.shared.inc.helpers.gtfs_helpers import compute_gtfs_day_from_resource_path, compute_gtfs_db_filename
 from inc.shared.inc.models.ckan_data import CKAN_Data
 
-PYTHON_PATH = sys.executable
-row_delimiter_s = '='*70
+from inc.common import PYTHON_PATH, fetch_latest_resource, check_latest_data_folder
 
 def main():
     script_path = Path(os.path.realpath(__file__))
     app_config = load_convenience_config(script_path)
-
-    _fetch_latest_resource(script_path, 'gtfs_static')
-    gtfs_data_path = _check_latest_data_folder(app_config)
-    _db_import(app_config, script_path, gtfs_data_path)
     
-    _dbs_aggregate(script_path)
-    
-def _fetch_latest_resource(script_path, package_key):
-    # fetch latest archive
-    ckan_fetch_cli_path = f'{script_path.parent}/../ckan-utils/fetch_package_cli.py'
-    ckan_fetch_sh = f'{PYTHON_PATH} {ckan_fetch_cli_path} --package_key {package_key}'
+    package_id = app_config['current_package_ids']['gtfs']
     
     print('START ./tools/scripts/gtfs-compute-latest.py')
     print()
     print('Resources:')
-    print('  - https://opentransportdata.swiss/en/dataset/timetable-54-2024-hrdf')
-    print('  - https://tools.odpch.ch/hrdf-dbs/hrdf-dbs.json')
+    print(f'    - https://data.opentransportdata.swiss/en/dataset/{package_id}')
+    print('     - https://tools.odpch.ch/gtfs-static-dbs/gtfs-static-dbs.json')
     print('')
     
-    print('STEP 1 - FETCH LATEST ARCHIVE')
-    print(ckan_fetch_sh, flush=True)
-    os.system(ckan_fetch_sh)
-
-def _check_latest_data_folder(app_config):
-    # check latest folder
-    print('')
-    print('STEP 2 - CHECK LATEST GTFS DATASET')
+    fetch_latest_resource(script_path, package_id)
+    gtfs_data_path = check_latest_data_folder(app_config, package_id)
+    _db_import(app_config, script_path, gtfs_data_path)
     
-    gtfs_ckan_json_path = app_config['resource_paths']['ckan_gtfs_static_json']
-    gtfs_ckan_json = load_json_from_file(gtfs_ckan_json_path)
-    gtfs_ckan = CKAN_Data.from_ckan_json(gtfs_ckan_json)
-    
-    ckan_resource = gtfs_ckan.result.resources[0]
-    
-    resources_base_folder_path = app_config['data_paths']['gtfs-static']
-    
-    resource_folder_name = ckan_resource.title['en']
-    # zip resources are unzipped in fetch, use the unzipped folder name
-    resource_folder_name = resource_folder_name[0:-4]
-    
-    resource_path = Path(f'{resources_base_folder_path}/{resource_folder_name}')
-    
-    if not os.path.isdir(resource_path):
-        print()
-        print(row_delimiter_s)
-        print('ERROR - latest resource not found at path')
-        print(resource_path)
-        print(row_delimiter_s)
-        sys.exit(1)
-        
-    print(f'... use following resource: {resource_path}')
-        
-    return resource_path
+    _dbs_aggregate(script_path)
 
 def _db_import(app_config, script_path, gtfs_data_path):
     gtfs_day = compute_gtfs_day_from_resource_path(gtfs_data_path)

--- a/tools/scripts/gtfs-compute-latest.py
+++ b/tools/scripts/gtfs-compute-latest.py
@@ -84,7 +84,9 @@ def _db_import(app_config, script_path, gtfs_data_path):
     else:
         import_cli_path = f'{script_path.parent}/../gtfs-static-db-importer/gtfs_db_importer_cli.py'
         import_sh = f'{PYTHON_PATH} {import_cli_path} --gtfs-folder-path {gtfs_data_path}'
-        print(import_sh, flush=True)
+        print()
+        print(f'$ {import_sh}', flush=True)
+        print()
         os.system(import_sh)
 
     return gtfs_db_path
@@ -95,7 +97,9 @@ def _dbs_aggregate(script_path):
     
     cli_path = f'{script_path.parent}/../gtfs-static-db-importer/cli_aggregate_dbs.py'
     cli_sh = f'{PYTHON_PATH} {cli_path}'
-    print(cli_sh, flush=True)
+    print()
+    print(f'$ {cli_sh}', flush=True)
+    print()
     os.system(cli_sh)
 
 if __name__ == "__main__":

--- a/tools/scripts/hrdf-compute-latest.py
+++ b/tools/scripts/hrdf-compute-latest.py
@@ -9,67 +9,29 @@ from inc.shared.inc.helpers.json_helpers import load_json_from_file
 from inc.shared.inc.helpers.hrdf_helpers import compute_formatted_date_from_hrdf_folder_path, compute_hrdf_db_filename, compute_formatted_date_from_hrdf_db_path
 from inc.shared.inc.models.ckan_data import CKAN_Data
 
-PYTHON_PATH = sys.executable
-row_delimiter_s = '='*70
+from inc.common import PYTHON_PATH, fetch_latest_resource, check_latest_data_folder
 
 def main():
     script_path = Path(os.path.realpath(__file__))
     app_config = load_convenience_config(script_path)
+    
+    package_id = app_config['current_package_ids']['hrdf']
+    
+    print('START ./tools/scripts/hrdf-compute-latest.py')
+    print()
+    print('Resources:')
+    print(f'    - https://data.opentransportdata.swiss/en/dataset/{package_id}')
+    print('  - https://tools.odpch.ch/hrdf-dbs/hrdf-dbs.json')
+    print('')
 
-    _fetch_latest_resource(script_path, 'hrdf_5_4')
-    hrdf_data_path = _check_latest_data_folder(app_config)
+    fetch_latest_resource(script_path, package_id)
+    hrdf_data_path = check_latest_data_folder(app_config, package_id)
+
     hrdf_db_path = _db_import(app_config, script_path, hrdf_data_path)
     _dbs_aggregate(script_path)
     _hrdf_check_duplicates(script_path, hrdf_db_path)
     _hrdf_build_aggregated_duplicates(script_path)
     _hrdf_generate_lookups(script_path, hrdf_db_path)
-    
-def _fetch_latest_resource(script_path, package_key):
-    # fetch latest archive
-    ckan_fetch_cli_path = f'{script_path.parent}/../ckan-utils/fetch_package_cli.py'
-    ckan_fetch_sh = f'{PYTHON_PATH} {ckan_fetch_cli_path} --package_key {package_key}'
-    
-    print('START ./tools/scripts/hrdf-compute-latest.py')
-    print()
-    print('Resources:')
-    print('  - https://opentransportdata.swiss/en/dataset/timetable-2024-gtfs2020')
-    print('  - https://tools.odpch.ch/gtfs-static-dbs/gtfs-static-dbs.json')
-    print('')
-    
-    print('STEP 1 - FETCH LATEST ARCHIVE')
-    print(ckan_fetch_sh, flush=True)
-    os.system(ckan_fetch_sh)
-
-def _check_latest_data_folder(app_config):
-    # check latest folder
-    print('')
-    print('STEP 2 - CHECK LATEST FOLDER')
-    
-    ckan_json_path = app_config['resource_paths']['ckan_hrdf_json']
-    ckan_json = load_json_from_file(ckan_json_path)
-    hrdf_ckan = CKAN_Data.from_ckan_json(ckan_json)
-    
-    ckan_resource = hrdf_ckan.result.resources[0]
-    
-    resources_base_folder_path = app_config['data_paths']['hrdf-opentransportdata.swiss']
-    
-    resource_folder_name = ckan_resource.title['en']
-    # zip resources are unzipped in fetch, use the unzipped folder name
-    resource_folder_name = resource_folder_name[0:-4]
-    
-    resource_path = Path(f'{resources_base_folder_path}/{resource_folder_name}')
-    
-    if not os.path.isdir(resource_path):
-        print()
-        print(row_delimiter_s)
-        print('ERROR - latest resource not found at path')
-        print(resource_path)
-        print(row_delimiter_s)
-        sys.exit(1)
-        
-    print(f'... use following resource: {resource_path}')
-    
-    return resource_path
 
 def _db_import(app_config, script_path, hrdf_data_path):
     hrdf_day = compute_formatted_date_from_hrdf_folder_path(hrdf_data_path)

--- a/tools/scripts/hrdf-compute-latest.py
+++ b/tools/scripts/hrdf-compute-latest.py
@@ -88,7 +88,9 @@ def _db_import(app_config, script_path, hrdf_data_path):
     else:
         hrdf_import_cli_path = f'{script_path.parent}/../hrdf-db-importer/hrdf_db_importer_cli.py'
         hrdf_import_sh = f'{PYTHON_PATH} {hrdf_import_cli_path} --hrdf-folder-path {hrdf_data_path}'
-        print(hrdf_import_sh, flush=True)
+        print()
+        print(f'$ {hrdf_import_sh}', flush=True)
+        print()
         os.system(hrdf_import_sh)
 
     return hrdf_db_path
@@ -99,7 +101,9 @@ def _dbs_aggregate(script_path):
     
     cli_path = f'{script_path.parent}/../hrdf-db-importer/cli_aggregate_dbs.py'
     cli_sh = f'{PYTHON_PATH} {cli_path}'
-    print(cli_sh, flush=True)
+    print()
+    print(f'$ {cli_sh}', flush=True)
+    print()
     os.system(cli_sh)
 
 def _hrdf_check_duplicates(script_path, hrdf_db_path):
@@ -122,7 +126,9 @@ def _hrdf_check_duplicates(script_path, hrdf_db_path):
     else:
         tool_cli_path = f'{hrdf_duplicates_tool_folder_path}/hrdf_check_duplicates_cli.py'
         tool_cli_sh = f"{PYTHON_PATH} {tool_cli_path} \\\n  --hrdf-db-path {hrdf_db_path}"
-        print(tool_cli_sh, flush=True)
+        print()
+        print(f'$ {tool_cli_sh}', flush=True)
+        print()
         os.system(tool_cli_sh)
 
 def _hrdf_build_aggregated_duplicates(script_path):
@@ -147,7 +153,9 @@ def _hrdf_build_aggregated_duplicates(script_path):
     if run_cli:
         tool_cli_path = f'{hrdf_duplicates_tool_folder_path}/hrdf_build_consolidated_report_cli.py'
         tool_cli_sh = f"{PYTHON_PATH} {tool_cli_path}"
-        print(tool_cli_sh, flush=True)
+        print()
+        print(f'$ {tool_cli_sh}', flush=True)
+        print()
         os.system(tool_cli_sh)
     else:
         print(f'Report already present at path and not too old')
@@ -164,7 +172,9 @@ def _hrdf_generate_lookups(script_path, hrdf_db_path):
 
     tool_cli_path = f'{tool_cli_folder_path}/hrdf_db_lookups_generator_cli.py'
     tool_cli_sh = f"{PYTHON_PATH} {tool_cli_path} \\\n  --hrdf-db-path {hrdf_db_path}"
-    print(tool_cli_sh, flush=True)
+    print()
+    print(f'$ {tool_cli_sh}', flush=True)
+    print()
     os.system(tool_cli_sh)
     
 if __name__ == "__main__":

--- a/tools/scripts/inc/common.py
+++ b/tools/scripts/inc/common.py
@@ -1,0 +1,84 @@
+import os
+import sys
+
+from pathlib import Path
+from .shared.inc.helpers.json_helpers import load_json_from_file
+from .shared.inc.models.ckan_data import CKAN_Data
+
+PYTHON_PATH = sys.executable
+ROW_DELIMITER_S = '='*70
+
+def fetch_latest_resource(script_path: Path, package_id: str):
+    # fetch latest archive
+    ckan_fetch_cli_path = f'{script_path.parent}/../ckan-utils/fetch_package_cli.py'
+    ckan_fetch_sh = f'{PYTHON_PATH} {ckan_fetch_cli_path} --package_id {package_id}'
+    
+    print('STEP 1 - FETCH LATEST ARCHIVE')
+    print(ckan_fetch_sh, flush=True)
+    os.system(ckan_fetch_sh)
+    
+def compute_ckan_data(app_config, package_id: str):
+    ckan_metadata_path: str = app_config['resource_paths']['ckan_metadata_path']
+    ckan_metadata_path = ckan_metadata_path.replace('[PACKAGE_ID]', package_id)
+    ckan_metadata_json = load_json_from_file(ckan_metadata_path)
+    ckan_data = CKAN_Data.from_ckan_json(ckan_metadata_json)
+    
+    return ckan_data
+
+def check_latest_data_folder(app_config, package_id: str):
+    # check latest folder
+    print('')
+    print(f'STEP 2 - CHECK LATEST DATASET {package_id}')
+    
+    ckan_data = compute_ckan_data(app_config, package_id)
+    
+    # convention: first resource is the latest published
+    ckan_resource = ckan_data.result.resources[0]
+    
+    resources_base_folder_path: str = app_config['data_paths']['opentransportdata']['package_base_path']
+    resources_base_folder_path = resources_base_folder_path.replace('[PACKAGE_ID]', package_id)
+    
+    resource_folder_name = ckan_resource.title['en']
+    # zip resources are unzipped in fetch, use the unzipped folder name
+    resource_folder_name = resource_folder_name[0:-4]
+    
+    resource_path = Path(f'{resources_base_folder_path}/{resource_folder_name}')
+    
+    if not os.path.isdir(resource_path):
+        print()
+        print(ROW_DELIMITER_S)
+        print('ERROR - latest resource not found at path')
+        print(resource_path)
+        print(ROW_DELIMITER_S)
+        sys.exit(1)
+    
+    print(f'... use following resource: {resource_path}')
+    
+    return resource_path
+
+def compute_ckan_resource_by_prefix(app_config, package_id: str, resource_prefix: str):
+    ckan_data = compute_ckan_data(app_config, package_id)
+    
+    ckan_resource = None
+    for ckan_resource_item in ckan_data.result.resources:
+        resource_title: str = ckan_resource_item.title['en']
+        if not resource_title.startswith(resource_prefix):
+            continue
+        
+        ckan_resource = ckan_resource_item
+        break
+    # loop resources
+    
+    if ckan_resource is None:
+        print()
+        print(ROW_DELIMITER_S)
+        print('ERROR - ckan resource cant be found')
+        print()
+        print(ckan_data.result.resources)
+        print()
+        print(ROW_DELIMITER_S)
+        sys.exit(1)
+    #
+        
+    return ckan_resource
+

--- a/tools/scripts/inc/common.py
+++ b/tools/scripts/inc/common.py
@@ -38,9 +38,13 @@ def check_latest_data_folder(app_config, package_id: str):
     resources_base_folder_path: str = app_config['data_paths']['opentransportdata']['package_base_path']
     resources_base_folder_path = resources_base_folder_path.replace('[PACKAGE_ID]', package_id)
     
-    resource_folder_name = ckan_resource.title['en']
+    if ckan_resource.extension != '.zip':
+        print(f'ERROR: expected ZIP archive for {package_id}')
+        print(ckan_resource)
+        sys.exit(1)
+    
     # zip resources are unzipped in fetch, use the unzipped folder name
-    resource_folder_name = resource_folder_name[0:-4]
+    resource_folder_name = ckan_resource.filename[0:-4]
     
     resource_path = Path(f'{resources_base_folder_path}/{resource_folder_name}')
     
@@ -61,8 +65,7 @@ def compute_ckan_resource_by_prefix(app_config, package_id: str, resource_prefix
     
     ckan_resource = None
     for ckan_resource_item in ckan_data.result.resources:
-        resource_title: str = ckan_resource_item.title['en']
-        if not resource_title.startswith(resource_prefix):
+        if not ckan_resource_item.filename.startswith(resource_prefix):
             continue
         
         ckan_resource = ckan_resource_item

--- a/tools/scripts/inc/config.yml
+++ b/tools/scripts/inc/config.yml
@@ -1,27 +1,40 @@
-data_paths:
-  gtfs-db-lookups: [APP_PATH]/data/gtfs-db-lookups
-  gtfs-rt-snapshot: [APP_PATH]/data/gtfs-rt-snapshot
-  gtfs-rt-static-compare-report: [APP_PATH]/data/gtfs-rt-static-compare-report
-  gtfs-rt-static-compare-tmp: [APP_PATH]/data/gtfs-rt-static-compare-tmp
-  gtfs-static: &GTFS_STATIC_DATA_PATH [APP_PATH]/data/opentransportdata.swiss/gtfs-static
-  gtfs-static-dbs: &GTFS_STATIC_DBS_PATH [APP_PATH]/data/gtfs-static-dbs
-  gtfs-query-db-cache: [APP_PATH]/data/gtfs-query-db-cache
-  
-  hrdf-query-db-cache: [APP_PATH]/data/hrdf-query-db-cache
-  hrdf-opentransportdata.swiss: &HRDF_DATA_PATH [APP_PATH]/data/opentransportdata.swiss/hrdf
-  hrdf-dbs: &HRDF_DBS_PATH [APP_PATH]/data/hrdf-dbs
-  hrdf-db-lookups: [APP_PATH]/data/hrdf-db-lookups
-  hrdf-duplicates-reports: [APP_PATH]/data/hrdf-duplicates-reports
-  hrdf-duplicates-reports-csv: [APP_PATH]/data/hrdf-duplicates-reports/hrdf-duplicates-reports-csv
+current_package_ids:
+  gtfs: timetable-2025-gtfs2020
+  hrdf: timetable-54-2025-hrdf
 
-  go_data: [APP_PATH]/data/opentransportdata.swiss/business-organisations
-  go_latest: [APP_PATH]/data/opentransportdata.swiss/business-organisations/actual_date_business_organisation_versions_LATEST.csv
+csv_latest_data:  
+  # https://data.opentransportdata.swiss/en/dataset/business-organisations
+  business-organisations:
+    example: actual_date_business_organisation_versions_2025-01-17.csv
+    file_prefix: actual_date_business_organisation_versions
+    symlink_latest_path: "[APP_PATH]/data/opentransportdata.swiss/[PACKAGE_ID]/[PREFIX]_LATEST.csv"
   
-  go-realtime_data: [APP_PATH]/data/opentransportdata.swiss/go-realtime
-  go-realtime_latest: [APP_PATH]/data/opentransportdata.swiss/go-realtime/business_organisation_realtime_LATEST.csv
+  # https://data.opentransportdata.swiss/en/dataset/go-realtime
+  go-realtime:
+    example: go-realtime.csv
+  
+  # https://data.opentransportdata.swiss/en/dataset/slnid-line
+  slnid-line:
+    example: actual_date_line_versions_2025-01-17.csv
+    file_prefix: actual_date_line_versions
+    symlink_latest_path: "[APP_PATH]/data/opentransportdata.swiss/[PACKAGE_ID]/[PREFIX]_LATEST.csv"
+
+data_paths:
+  opentransportdata:
+    package_base_path: "[APP_PATH]/data/opentransportdata.swiss/[PACKAGE_ID]"
+
+  gtfs-db-lookups: "[APP_PATH]/data/gtfs-db-lookups"
+  gtfs-rt-snapshot: "[APP_PATH]/data/gtfs-rt-snapshot"
+  gtfs-rt-static-compare-report: "[APP_PATH]/data/gtfs-rt-static-compare-report"
+  gtfs-rt-static-compare-tmp: "[APP_PATH]/data/gtfs-rt-static-compare-tmp"
+  gtfs-static-dbs: "[APP_PATH]/data/gtfs-static-dbs"
+  gtfs-query-db-cache: "[APP_PATH]/data/gtfs-query-db-cache"
+  
+  hrdf-query-db-cache: "[APP_PATH]/data/hrdf-query-db-cache"
+  hrdf-dbs: "[APP_PATH]/data/hrdf-dbs"
+  hrdf-db-lookups: "[APP_PATH]/data/hrdf-db-lookups"
+  hrdf-duplicates-reports: "[APP_PATH]/data/hrdf-duplicates-reports"
+  hrdf-duplicates-reports-csv: "[APP_PATH]/data/hrdf-duplicates-reports/hrdf-duplicates-reports-csv"
 
 resource_paths:
-  ckan_gtfs_static_json: [APP_PATH]/data/ckan-utils-tmp/ckan_gtfs_static.json
-  ckan_hrdf_json: [APP_PATH]/data/ckan-utils-tmp/ckan_hrdf_5_4.json
-  ckan_go_json: [APP_PATH]/data/ckan-utils-tmp/ckan_go.json
-  ckan_go-realtime_json: [APP_PATH]/data/ckan-utils-tmp/ckan_go-realtime.json
+  ckan_metadata_path: "[APP_PATH]/data/ckan-utils-tmp/ckan_[PACKAGE_ID].json"


### PR DESCRIPTION
- more robust parsing, rely on `package_id` of the datasets
- use Python standard libs for fetching data and unzipping resources
- dont rely on resource `mimetype`, check the `url` instead and compute filename and filename extension
- adapt `gtfs-static-db-importer`, `hrdf-db-importer` tools to use the new config / approach
- adjust `scripts/cli_opentransportdata_csv_fetch_latest.py` CSV data importer, adds [slnid-line](https://data.opentransportdata.swiss/en/dataset/slnid-line) dataset