### PR TITLE
Extend gtfs-query tool

### DIFF
--- a/apps/gtfs-query/.htaccess
+++ b/apps/gtfs-query/.htaccess
@@ -4,6 +4,7 @@ Options -MultiViews
 RewriteEngine On
 
 RewriteRule db_lookups$ db_lookups.php [L,QSA]
+RewriteRule query_routes_representative_trip$ query_routes_representative_trip.php [L,QSA]
 RewriteRule query_day_trips$ query_day_trips.php [L,QSA]
 RewriteRule query_day_from_to_trips$ query_day_from_to_trips.php [L,QSA]
 RewriteRule lookup/([a-zA-Z0-9]+?)$ select_table.php?table_name=$1 [L]

--- a/apps/gtfs-query/README.md
+++ b/apps/gtfs-query/README.md
@@ -193,6 +193,13 @@ This API returns all active trips for a given interval or running at a given tim
 }
 ```
 
+## Query routes representative trip
+
+This API returns the most representative trip for each `routes` row. The ranking is done by aggregating number of `calendar.day_bits` `1` values and the number of stops.
+
+`GET /query_routes_representative_trip`
+
+The output is similar with `/trips` API
 
 ## Query Single Trip
 

--- a/apps/gtfs-query/inc/config.yml
+++ b/apps/gtfs-query/inc/config.yml
@@ -11,6 +11,7 @@ go_realtime_csv_path: "[APP_PATH]/data/opentransportdata.swiss/go-realtime/busin
 map_sql_queries:
     # select
     query_day_trips: "[APP_PATH]/inc/sql/gtfs/query_day_trips.sql"
+    query_routes_representative_trip: "[APP_PATH]/inc/sql/gtfs/query_routes_representative_trip.sql"
     # where
     where_from_to_trips: "[APP_PATH]/inc/sql/gtfs/where/where_from_to_trips.sql"
     # fields

--- a/apps/gtfs-query/inc/config.yml
+++ b/apps/gtfs-query/inc/config.yml
@@ -14,6 +14,7 @@ map_sql_queries:
     query_routes_representative_trip: "[APP_PATH]/inc/sql/gtfs/query_routes_representative_trip.sql"
     # where
     where_from_to_trips: "[APP_PATH]/inc/sql/gtfs/where/where_from_to_trips.sql"
+    where_day_bits_day_idx: "[APP_PATH]/inc/sql/gtfs/where/where_day_bits_day_idx.sql"
     # fields
     fields_query_day_full_trips: "[APP_PATH]/inc/sql/gtfs/fields/query_day_full_trips.sql"
     fields_query_day_light_trips: "[APP_PATH]/inc/sql/gtfs/fields/query_day_light_trips.sql"

--- a/apps/gtfs-query/inc/gtfs_db_controller.php
+++ b/apps/gtfs-query/inc/gtfs_db_controller.php
@@ -512,7 +512,6 @@ class GTFS_DB_Controller {
 
         $cache_filename_parts = array(
             'query_agency_trips_' . $this->cache_prefix,
-            'gtfs_day_' . $this->gtfs_db_day,
             'service_day_' . $service_day,
             'agency_id_' . $agency_id,
         );

--- a/apps/gtfs-query/inc/gtfs_db_controller.php
+++ b/apps/gtfs-query/inc/gtfs_db_controller.php
@@ -49,7 +49,7 @@ class GTFS_DB_Controller {
 
         $this->use_cache = TRUE;
 
-        $this->cache_prefix = 'v1_' . $gtfs_db_day;
+        $this->cache_prefix = 'v2_' . $gtfs_db_day;
 
         $sql_builder_config_path = $config['sql_builder_path'];
         $this->sql_builder_config = ConfigHelpers::loadConfigAtPath($sql_builder_config_path);

--- a/apps/gtfs-query/inc/gtfs_db_controller.php
+++ b/apps/gtfs-query/inc/gtfs_db_controller.php
@@ -630,6 +630,30 @@ class GTFS_DB_Controller {
         return $result;
     }
 
+    public function query_routes_representative_trip() {
+        $sql_path = $this->map_sql_queries['query_routes_representative_trip'];
+        $sql = file_get_contents($sql_path);
+
+        $cache_filename_parts = array(
+            'query_routes_representative_trip_' . $this->cache_prefix,
+        );
+        $cache_filename = implode('__', $cache_filename_parts) . '.json';
+        $cache_path = $this->app_db_cache_path . '/' . $cache_filename;
+
+        $cache_result = $this->compute_cache_result($cache_path);
+        if ($cache_result) {
+            return $cache_result;
+        }
+
+        $result = $this->db->query($sql);
+
+        $result_rows = array();
+        while ($db_row = $result->fetchArray(SQLITE3_ASSOC)) {
+            array_push($result_rows, $db_row);
+        }
+
+        $result = $this->_compute_and_cache_result($sql, $result_rows, $cache_path);
+
         return $result;
     }
 

--- a/apps/gtfs-query/inc/gtfs_db_controller.php
+++ b/apps/gtfs-query/inc/gtfs_db_controller.php
@@ -666,8 +666,10 @@ class GTFS_DB_Controller {
         if ($service_day) {
             $request_day_date = date_create_from_format("Y-m-d", $service_day);
             $day_idx = $request_day_date->diff($this->gtfs_from_date)->days;
-    
-            $service_day_where = "SUBSTR(calendar.day_bits, " . $day_idx . " + 1, 1) = '1'";
+
+            $service_day_where = file_get_contents($this->map_sql_queries['where_day_bits_day_idx']);
+            $service_day_where = str_replace('[DAY_IDX]', $day_idx, $service_day_where);
+
             array_push($query_config['where'], $service_day_where);
         }
 

--- a/apps/gtfs-query/inc/gtfs_db_controller.php
+++ b/apps/gtfs-query/inc/gtfs_db_controller.php
@@ -615,16 +615,28 @@ class GTFS_DB_Controller {
         return $result;
     }
 
+    private function compute_cache_result($cache_path) {
+        if (!($this->use_cache && file_exists($cache_path))) {
+            return null;
+        }
+            
+        $cache_path_parts = explode('/', $cache_path);
+        $cache_filename = $cache_path_parts[count($cache_path_parts) - 1];
+
+        $result_s = file_get_contents($cache_path);
+        $result = json_decode($result_s, TRUE);
+        $result['metadata']['cache'] = $cache_filename;
+
+        return $result;
+    }
+
+        return $result;
+    }
+
     private function _query_trips($query_config, $service_day = null, $cache_path = null) {
-        if ($this->use_cache && $cache_path && file_exists($cache_path)) {
-            $cache_path_parts = explode('/', $cache_path);
-            $cache_filename = $cache_path_parts[count($cache_path_parts) - 1];
-
-            $result_s = file_get_contents($cache_path);
-            $result = json_decode($result_s, TRUE);
-            $result['metadata']['cache'] = $cache_filename;
-
-            return $result;
+        $cache_result = $this->compute_cache_result($cache_path);
+        if ($cache_result) {
+            return $cache_result;
         }
 
         if ($service_day) {
@@ -645,6 +657,12 @@ class GTFS_DB_Controller {
             array_push($result_rows, $db_row);
         }
 
+        $this->_compute_and_cache_result($sql, $result_rows, $cache_path);
+
+        return $result;
+    }
+
+    private function _compute_and_cache_result($sql, $result_rows, $cache_path) {
         $result = array(
             'metadata' => array(
                 'gtfs_day' => $this->gtfs_db_day,

--- a/apps/gtfs-query/inc/gtfs_db_controller.php
+++ b/apps/gtfs-query/inc/gtfs_db_controller.php
@@ -681,7 +681,7 @@ class GTFS_DB_Controller {
             array_push($result_rows, $db_row);
         }
 
-        $this->_compute_and_cache_result($sql, $result_rows, $cache_path);
+        $result = $this->_compute_and_cache_result($sql, $result_rows, $cache_path);
 
         return $result;
     }

--- a/apps/gtfs-query/inc/gtfs_schema.yml
+++ b/apps/gtfs-query/inc/gtfs_schema.yml
@@ -1,0 +1,1 @@
+../../../tools/gtfs-static-db-importer/inc/config/gtfs_schema.yml

--- a/apps/gtfs-query/query_routes_representative_trip.php
+++ b/apps/gtfs-query/query_routes_representative_trip.php
@@ -1,0 +1,10 @@
+<?php
+define('APP_PATH', dirname(__FILE__));
+include(APP_PATH . '/inc/common.php');
+
+$gtfs_day = @$_GET['gtfs_day'] ?: 'LATEST';
+
+$gtfs_controller = new GTFS_DB_Controller(APP_CONFIG, $gtfs_day);
+$result_json = $gtfs_controller->query_routes_representative_trip();
+
+JsonView::dump($result_json);

--- a/apps/gtfs-query/trips.php
+++ b/apps/gtfs-query/trips.php
@@ -22,14 +22,14 @@ if (!is_null($route_short_name) && !is_null($line_ref)) {
     die;
 }
 
-if (!is_null($agency_id) && !is_null($service_day)) {
-    $response = $gtfs_controller->query_trips_by_agency_for_service_day($agency_id, $service_day);
+if (!is_null($agency_id) && !is_null($route_short_name)) {
+    $response = $gtfs_controller->query_trips_by_agency_route_short_name($agency_id, $route_short_name, $trip_short_name, $service_day);
     JsonView::dump($response);
     die;
 }
 
-if (!is_null($agency_id) && !is_null($route_short_name)) {
-    $response = $gtfs_controller->query_trips_by_agency_route_short_name($agency_id, $route_short_name, $trip_short_name, $service_day);
+if (!is_null($agency_id) && !is_null($service_day)) {
+    $response = $gtfs_controller->query_trips_by_agency_for_service_day($agency_id, $service_day);
     JsonView::dump($response);
     die;
 }

--- a/tools/_shared/inc/sql/gtfs/query_routes_representative_trip.sql
+++ b/tools/_shared/inc/sql/gtfs/query_routes_representative_trip.sql
@@ -1,0 +1,13 @@
+SELECT trips.* 
+FROM routes
+LEFT JOIN trips ON 
+trips.trip_id IN (
+    SELECT 
+        trips.trip_id
+        FROM trips, calendar 
+        WHERE trips.route_id =  routes.route_id
+        AND trips.service_id = calendar.service_id
+        -- TRIPS with most day_bit '1'
+        ORDER BY LENGTH(REPLACE(calendar.day_bits, '0', '')) DESC
+    LIMIT 1
+)

--- a/tools/_shared/inc/sql/gtfs/query_routes_representative_trip.sql
+++ b/tools/_shared/inc/sql/gtfs/query_routes_representative_trip.sql
@@ -4,10 +4,17 @@ LEFT JOIN trips ON
 trips.trip_id IN (
     SELECT 
         trips.trip_id
-        FROM trips, calendar 
-        WHERE trips.route_id =  routes.route_id
-        AND trips.service_id = calendar.service_id
-        -- TRIPS with most day_bit '1'
-        ORDER BY LENGTH(REPLACE(calendar.day_bits, '0', '')) DESC
+        FROM trips, calendar
+        WHERE 
+            trips.route_id =  routes.route_id
+            AND trips.service_id = calendar.service_id
+        GROUP BY trips.trip_id
+        ORDER BY (
+            -- most calendar days (values: 0..360) * 10 (for normalisation)
+            LENGTH(REPLACE(calendar.day_bits, '0', '')) * 10
+            + 
+            -- max number of stops (max in ch is 80)
+			trips.stop_times_count
+        ) DESC
     LIMIT 1
 )

--- a/tools/_shared/inc/sql/gtfs/where/where_day_bits_day_idx.sql
+++ b/tools/_shared/inc/sql/gtfs/where/where_day_bits_day_idx.sql
@@ -1,0 +1,14 @@
+(
+    -- current day trip
+    ( SUBSTR(calendar.day_bits, [DAY_IDX] + 1, 1) = '1' )
+    OR
+    -- check for prev day trip that are going over midnight
+    (
+        -- is after-midnight trip
+        ( trips.arrival_day_minutes > 24 * 60 )
+        -- prev day_bit is '1'
+        AND (SUBSTR(calendar.day_bits, [DAY_IDX], 1) = '1')
+        -- current day_bit is '0'
+        AND (SUBSTR(calendar.day_bits, [DAY_IDX] + 1, 1) = '0')
+    )
+)

--- a/tools/gtfs-static-db-importer/CHANGELOG.md
+++ b/tools/gtfs-static-db-importer/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG gtfs-static-db-importer
 
+19.Jan 2025
+- adds `trips.stop_times_count` SQLite field + index needed by the [gtfs-query](https://github.com/openTdataCH/OJP-Showcase/tree/develop/apps/gtfs-query) app
+
 09.Jan 2025
 - fix `stop_times.stop_id` GROUP_CONCAT queries which might occur in unexpected results
 

--- a/tools/gtfs-static-db-importer/inc/config/gtfs_schema.yml
+++ b/tools/gtfs-static-db-importer/inc/config/gtfs_schema.yml
@@ -99,6 +99,7 @@ tables:
             - departure_time TEXT
             - arrival_time TEXT
             - stop_times_s TEXT # added to avoid GROUP_BY queries
+            - stop_times_count INTEGER # added to avoid GROUP_BY queries
             - shape_id TEXT
             - original_trip_id TEXT # https://opentransportdata.swiss/en/cookbook/gtfs/#tripstxt
         indexes:
@@ -109,3 +110,4 @@ tables:
             - arrival_day_minutes
             - trip_short_name
             - original_trip_id
+            - stop_times_count

--- a/tools/gtfs-static-db-importer/inc/db_importer.py
+++ b/tools/gtfs-static-db-importer/inc/db_importer.py
@@ -340,6 +340,7 @@ class GTFS_DB_Importer:
             trip_new_row['arrival_day_minutes'] = None
             trip_new_row['arrival_time'] = None
             trip_new_row['stop_times_s'] = None
+            trip_new_row['stop_times_count'] = None
 
             for stop_type in ['from', 'to']:
                 db_rowid = None
@@ -384,6 +385,7 @@ class GTFS_DB_Importer:
                 trip_stop_times_values.append(stop_time_value)
 
             trip_new_row['stop_times_s'] = ' -- '.join(trip_stop_times_values)
+            trip_new_row['stop_times_count'] = len(stop_times)
 
             new_trips_table_csv.writerow(trip_new_row)
 


### PR DESCRIPTION
- add `/query_routes_representative_trip` API which returns the representative trip for each `routes` row. The ranking is done by aggregating `1` occurences in `calendar.day_bits` and the number of stops.
- adds new SQLite field, `trips.stop_times_count` needed by the API above, patch the `tools/gtfs-static-db-importer` tool
- patch the `/trips` API to include also trips that are starting the day before and spread over midnight