### PR TITLE
Fix atlas-routes-compare-gtfs cases

### DIFF
--- a/apps/_shared/ts/helpers/gtfs-helpers.ts
+++ b/apps/_shared/ts/helpers/gtfs-helpers.ts
@@ -1,0 +1,21 @@
+export class GTFS_Helpers {
+  public static convertToSloid(s: string): string {
+    const isAlreadySloid = s.includes(':sloid:');
+    if (isAlreadySloid) {
+      return s;
+    }
+
+    if (s.startsWith('85')) {
+      // strip from 3rd character on
+      const sloidLocation = s.substring(2)
+        // strip any leading zeros
+        .replace(/^0*/, '');
+      
+      const sloid = 'ch:1:sloid:' + sloidLocation;
+      
+      return sloid;
+    }
+
+    return s;
+  }
+}

--- a/apps/atlas-routes-compare-gtfs/src/app/app.component.html
+++ b/apps/atlas-routes-compare-gtfs/src/app/app.component.html
@@ -68,8 +68,8 @@
                     <option *ngFor="let agencySelectRow of this.model.reportData.agencySelectRows; index as idx" [value]="agencySelectRow.organisation.sboid">{{ agencySelectRow.organisation.descriptionDe + ' - ' + agencySelectRow.organisation.abbreviationDe }} ({{ (agencySelectRow.stats.matchedOK_No + agencySelectRow.stats.matchedFuzzy_No) }} / {{ agencySelectRow.stats.routesNo }})</option>
                   </select>
                 </div>
-                <div>Filter</div>
-                <div style="width: 400px;"><input class="form-control" placeholder="type to filter (name, code, sboid)" [formControl]="filterAgencyInputControl" /></div>
+                <div>Filter by Text</div>
+                <div style="width: 400px;"><input class="form-control" placeholder="type to filter (name, code, sboid, slnid)" [formControl]="filterAgencyInputControl" /></div>
               </div>
 
               <hr/>
@@ -99,7 +99,7 @@
                     </div>
                     
                     <ng-container *ngFor="let routeReportRow of agencyReportRow.routeReportRows; index as idx2">
-                      <div class="card mb-3" *ngIf="this.model.filter.byMatchedStatus[routeReportRow.matchedStatus]">
+                      <div class="card mb-3" *ngIf="routeReportRow.showInGUI">
                         <div class="card-header d-flex">
                           <div class="flex-grow-1"><strong>{{ routeReportRow.atlasRoute.number }} - {{ routeReportRow.atlasRoute.slnid }} - {{ routeReportRow.atlasRoute.swissLineNumber }}</strong></div>
                           <div><span class="badge" ngClass="{{ routeReportRow.matchedStatusClassNames }}">{{ routeReportRow.matchedStatus }}</span></div>

--- a/apps/atlas-routes-compare-gtfs/src/app/app.component.html
+++ b/apps/atlas-routes-compare-gtfs/src/app/app.component.html
@@ -10,7 +10,11 @@
           <div class="content-header py-2 pt-3">
             <div class="mb-3 d-flex gap-2">
               <div class="flex-grow-1"><button type="button" class="btn btn-primary" (click)="fetchData()" [disabled]="this.isBusyProcessing()">Fetch</button></div>
-              <div><a href="https://gist.github.com/vasile/4de3b8ebf9ee195acae55558b3e8c6e2" target="_blank">Documentation</a></div>
+              <div>
+                <a href="https://github.com/openTdataCH/OJP-Showcase/tree/develop/apps/atlas-routes-compare-gtfs" target="_blank">Source Code</a>
+                |
+                <a href="https://gist.github.com/vasile/4de3b8ebf9ee195acae55558b3e8c6e2" target="_blank">Documentation</a>
+              </div>
             </div>
             <hr/>
 

--- a/apps/atlas-routes-compare-gtfs/src/app/app.component.html
+++ b/apps/atlas-routes-compare-gtfs/src/app/app.component.html
@@ -159,6 +159,6 @@
   </div>
 
   <footer class="bg-secondary text-white p-2 px-3">
-    <div>opentransportdata.swiss - v.2025-02-03</div>
+    <div>opentransportdata.swiss - v.2025-02-04</div>
   </footer>
 </div>

--- a/apps/atlas-routes-compare-gtfs/src/app/app.component.ts
+++ b/apps/atlas-routes-compare-gtfs/src/app/app.component.ts
@@ -27,7 +27,7 @@ interface PageModel {
 
   filter: {
     byMatchedStatus: Record<MatchedStatus, boolean>,
-    byAgencName: string,
+    byText: string,
   },
 }
 
@@ -59,7 +59,7 @@ export class AppComponent implements OnInit {
           'NO_MATCHES_FUZZY_OTHER_AGENCY': true,
           'NO_MATCHES': true,
         },
-        byAgencName: '',
+        byText: '',
       }    
     };
   }
@@ -71,7 +71,7 @@ export class AppComponent implements OnInit {
       distinctUntilChanged()
     )
     .subscribe((value: string) => {
-      this.model.filter.byAgencName = value.trim();
+      this.model.filter.byText = value.trim();
       this.updateFilteredItems();
     });
   }
@@ -244,19 +244,27 @@ export class AppComponent implements OnInit {
     console.log(this.model.filter);
 
     this.model.reportData.agencyFilterReportRows = this.model.reportData.agencyReportRows.filter(agencyReportRow => {
-      const keepAgencyByMatchStatus: boolean = (() => {
-        for (const routeReportRow of agencyReportRow.routeReportRows) {
-          if (this.model.filter.byMatchedStatus[routeReportRow.matchedStatus]) {
-            return true;
-          }
-        }
+      const isSLNID = this.model.filter.byText.includes(':slnid:');
 
-        return false;
-      })();
-      
+      // update showInGUI flag
+      agencyReportRow.routeReportRows.forEach(routeReportRow => {
+        if (isSLNID) {
+          const isSameSLNID = routeReportRow.atlasRoute.slnid === this.model.filter.byText;
+          routeReportRow.showInGUI = isSameSLNID;
+        } else {
+          routeReportRow.showInGUI = this.model.filter.byMatchedStatus[routeReportRow.matchedStatus];
+        }
+      });
+
+      const routeReportRowsInGUI = agencyReportRow.routeReportRows.find(el => el.showInGUI) ?? null;
+      const hasRoutesinGUI = routeReportRowsInGUI !== null;
 
       const keepAgencyByName: boolean = (() => {
-        const filterName = this.model.filter.byAgencName.toLowerCase().trim();
+        if (isSLNID) {
+          return true;
+        }
+
+        const filterName = this.model.filter.byText.toLowerCase().trim();
         if (filterName === '') {
           return true;
         }
@@ -291,7 +299,7 @@ export class AppComponent implements OnInit {
         return false;
       })();
 
-      return keepAgencyByMatchStatus && keepAgencyByName;
+      return hasRoutesinGUI && keepAgencyByName;
     });
 
     // Routes with most unmatched routes first

--- a/apps/atlas-routes-compare-gtfs/src/app/controllers/match-controller.ts
+++ b/apps/atlas-routes-compare-gtfs/src/app/controllers/match-controller.ts
@@ -256,6 +256,7 @@ export class MatchController {
       matchedGTFS_Trip: null,
       matchedGTFS_TripStopsText: null,
       matchNote: '',
+      showInGUI: true,
     };
 
     this.matchRouteByAgencyAndNumber(routeReportRow, matchIndexes, agencyId, atlasRouteNumber);

--- a/apps/atlas-routes-compare-gtfs/src/app/types/_all.ts
+++ b/apps/atlas-routes-compare-gtfs/src/app/types/_all.ts
@@ -25,6 +25,7 @@ export interface AgencyRouteReportRow {
   matchedGTFS_Trip: Trip | null
   matchedGTFS_TripStopsText: string | null
   matchNote: string,
+  showInGUI: boolean,
 }
 
 interface ReportStats {

--- a/apps/gtfs-query/README.md
+++ b/apps/gtfs-query/README.md
@@ -199,6 +199,12 @@ This API returns the most representative trip for each `routes` row. The ranking
 
 `GET /query_routes_representative_trip`
 
+### Query Params
+
+| Param | Description | Example |
+|-|-|-|
+| service_day | Optional, if present it will filter only for trips running in the given `service_day` | `2021-10-27` |
+
 The output is similar with `/trips` API
 
 ## Query Single Trip

--- a/apps/gtfs-query/inc/gtfs_db_controller.php
+++ b/apps/gtfs-query/inc/gtfs_db_controller.php
@@ -640,12 +640,23 @@ class GTFS_DB_Controller {
         return $result;
     }
 
-    public function query_routes_representative_trip() {
+    public function query_routes_representative_trip($service_day = null) {
         $sql_path = $this->map_sql_queries['query_routes_representative_trip'];
         $sql = file_get_contents($sql_path);
 
+        $sql_where_items = array();
+
+        if ($service_day !== null) {
+            $service_day_where = 'AND ' . $this->_compute_sql_service_day_where($service_day);
+            array_push($sql_where_items, $service_day_where);
+        }
+        
+        $sql_where_s = implode("\n", $sql_where_items);
+        $sql = str_replace('[EXTRA_WHERE]', $sql_where_s, $sql);
+
         $cache_filename_parts = array(
             'query_routes_representative_trip_' . $this->cache_prefix,
+            'service_day_' . ($service_day ?? 'ALL'),
         );
         $cache_filename = implode('__', $cache_filename_parts) . '.json';
         $cache_path = $this->app_db_cache_path . '/' . $cache_filename;

--- a/apps/gtfs-query/inc/gtfs_db_controller.php
+++ b/apps/gtfs-query/inc/gtfs_db_controller.php
@@ -701,6 +701,16 @@ class GTFS_DB_Controller {
         return $result;
     }
 
+    private function _compute_sql_service_day_where($service_day) {
+        $request_day_date = date_create_from_format("Y-m-d", $service_day);
+        $day_idx = $request_day_date->diff($this->gtfs_from_date)->days;
+
+        $service_day_where = file_get_contents($this->map_sql_queries['where_day_bits_day_idx']);
+        $service_day_where = str_replace('[DAY_IDX]', $day_idx, $service_day_where);
+
+        return $service_day_where;
+    }
+
     private function _compute_and_cache_result($sql, $result_rows, $cache_path) {
         $result = array(
             'metadata' => array(

--- a/apps/gtfs-query/inc/gtfs_db_controller.php
+++ b/apps/gtfs-query/inc/gtfs_db_controller.php
@@ -169,18 +169,12 @@ class GTFS_DB_Controller {
         return $result_json;
     }
 
-    private function query_db_trips($sql_fields, $day, $filter_agency_ids, $from_hhmm = null, $to_hhmm = null, $parse_db_row_type = null) {
-        // START compute DAY_IDX
+    private function query_db_trips($sql_fields, $service_day, $filter_agency_ids, $from_hhmm = null, $to_hhmm = null, $parse_db_row_type = null) {
         $sql_path = $this->map_sql_queries['query_day_trips'];
         $sql = file_get_contents($sql_path);
 
         $sql = str_replace('[SQL_FIELDS]', $sql_fields, $sql);
 
-        $request_day_date = date_create_from_format("Y-m-d", $day);
-        $day_idx = $request_day_date->diff($this->gtfs_from_date)->days;
-        $sql = str_replace('[DAY_IDX]', $day_idx, $sql);
-        // DONE
-        
         $sql_where_items = array();
         
         $sql_where_agency = $this->compute_agency_ids_sql_filter($filter_agency_ids);
@@ -190,6 +184,9 @@ class GTFS_DB_Controller {
             $sql_where_from_to = file_get_contents($this->map_sql_queries['where_from_to_trips']);
             array_push($sql_where_items, 'AND ' . $sql_where_from_to);
         }
+
+        $service_day_where = 'AND ' . $this->_compute_sql_service_day_where($service_day);
+        array_push($sql_where_items, $service_day_where);
 
         $sql_where_s = implode("\n", $sql_where_items);
         $sql = str_replace('[EXTRA_WHERE]', $sql_where_s, $sql);
@@ -676,13 +673,8 @@ class GTFS_DB_Controller {
             return $cache_result;
         }
 
-        if ($service_day) {
-            $request_day_date = date_create_from_format("Y-m-d", $service_day);
-            $day_idx = $request_day_date->diff($this->gtfs_from_date)->days;
-
-            $service_day_where = file_get_contents($this->map_sql_queries['where_day_bits_day_idx']);
-            $service_day_where = str_replace('[DAY_IDX]', $day_idx, $service_day_where);
-
+        if ($service_day !== null) {
+            $service_day_where = $this->_compute_sql_service_day_where($service_day);
             array_push($query_config['where'], $service_day_where);
         }
 

--- a/apps/gtfs-query/query_routes_representative_trip.php
+++ b/apps/gtfs-query/query_routes_representative_trip.php
@@ -3,8 +3,9 @@ define('APP_PATH', dirname(__FILE__));
 include(APP_PATH . '/inc/common.php');
 
 $gtfs_day = @$_GET['gtfs_day'] ?: 'LATEST';
+$service_day = @$_GET['service_day'] ?: null;
 
 $gtfs_controller = new GTFS_DB_Controller(APP_CONFIG, $gtfs_day);
-$result_json = $gtfs_controller->query_routes_representative_trip();
+$result_json = $gtfs_controller->query_routes_representative_trip($service_day);
 
 JsonView::dump($result_json);

--- a/tools/_shared/inc/sql/gtfs/query_day_trips.sql
+++ b/tools/_shared/inc/sql/gtfs/query_day_trips.sql
@@ -8,6 +8,3 @@ WHERE
     AND routes.agency_id = agency.agency_id
 
     [EXTRA_WHERE]
-
-    -- +1 is because the string index start at 1
-    AND SUBSTR(calendar.day_bits, [DAY_IDX] + 1, 1) = '1'

--- a/tools/_shared/inc/sql/gtfs/query_routes_representative_trip.sql
+++ b/tools/_shared/inc/sql/gtfs/query_routes_representative_trip.sql
@@ -1,13 +1,13 @@
-SELECT trips.* 
-FROM routes
+SELECT trips.* FROM routes
 LEFT JOIN trips ON 
 trips.trip_id IN (
     SELECT 
         trips.trip_id
         FROM trips, calendar
         WHERE 
-            trips.route_id =  routes.route_id
+            trips.route_id = routes.route_id
             AND trips.service_id = calendar.service_id
+            [EXTRA_WHERE]
         GROUP BY trips.trip_id
         ORDER BY (
             -- most calendar days (values: 0..360) * 10 (for normalisation)
@@ -18,3 +18,6 @@ trips.trip_id IN (
         ) DESC
     LIMIT 1
 )
+WHERE 
+    -- service_day filter might introduce routes without trips
+    trips.trip_id IS NOT NULL;

--- a/tools/atlas-geocode-lines/src/constants.ts
+++ b/tools/atlas-geocode-lines/src/constants.ts
@@ -23,7 +23,7 @@ export let DEBUG_slnid: string | null = null;
 export let DEBUG_Output_Names = false
 // DEBUG_Output_Names = true
 
-export let DEBUG_Row: string | null = 'Zone Seymaz-Voirons (Choulex, Gy, Jussy, Meinier, Presinge, Puplinge Collonge-Bellerive, Thônex, Vandoeuvres. Annemasse, Juvigny, Machilly, Saint-Cergues)'
+export let DEBUG_Row: string | null = 'Solothurn - Oberdorf - Moutier'
 DEBUG_Row = null
 
 export const STOP_NAME_SEPARATOR = ' |SEP| ';

--- a/tools/atlas-geocode-lines/src/constants.ts
+++ b/tools/atlas-geocode-lines/src/constants.ts
@@ -75,3 +75,15 @@ export const STOP_NAMES_LOOKUP = [
   'Schinznach Dorf', // Schinznach Dorf-Thalheim -> adds space -
 ];
 
+export const ADJUST_GEOCODER_REQUESTS: Record<string, string> = {
+  // S21: Oberdorf is matched to Oberdorf BL, we need the one in SO
+  'Solothurn - Oberdorf - Moutier': 'Solothurn - Oberdorf SO - Moutier',
+  // S25: Muri is matched to Muri bei Bern, we need Muri AG
+  'Muri - Brugg': 'Muri AG - Brugg',
+  // S30 need an extra station from Italy to be matched correctly
+  'Ranzo-S.Abbondio - Grenze*': 'Ranzo-S.Abbondio - Gallarate',
+  // ICE needs a station from DE
+  'Basel SBB - Deutschland': 'Basel SBB - Basel Bad Bf',
+  'Zürich Seilbahn Rigiblick - Rigiblick': 'Zürich Seilbahn Rigiblick - Zürich, Rigiblick',
+};
+

--- a/tools/atlas-geocode-lines/src/helpers/match-helpers.ts
+++ b/tools/atlas-geocode-lines/src/helpers/match-helpers.ts
@@ -1,4 +1,4 @@
-import { STOP_NAME_SEPARATOR, PSEUDO_SEPARATORS_DATA, SEPARATOR_WORDS_TO_IGNORE, STOP_NAMES_LOOKUP } from "../constants";
+import { STOP_NAME_SEPARATOR, PSEUDO_SEPARATORS_DATA, SEPARATOR_WORDS_TO_IGNORE, STOP_NAMES_LOOKUP, ADJUST_GEOCODER_REQUESTS } from "../constants";
 
 export class MatchHelpers {
   public static splitValuesStep1(inputNameS: string): string[] {
@@ -12,6 +12,11 @@ export class MatchHelpers {
       const regexp = new RegExp('(' + stopNameLookup + ')-\s?([A-Z][a-zäöü])', 'g');
       inputS = inputS.replaceAll(regexp, '$1' + STOP_NAME_SEPARATOR + '$2');
     });
+
+    for (const targetS in ADJUST_GEOCODER_REQUESTS) {
+      const replaceS = ADJUST_GEOCODER_REQUESTS[targetS];
+      inputS = inputS.replace(targetS, replaceS);
+    }
 
     inputS = inputS.replaceAll(' - ', STOP_NAME_SEPARATOR);
     inputS = inputS.replaceAll(' / ', STOP_NAME_SEPARATOR);

--- a/tools/ist-daten-filter/README.md
+++ b/tools/ist-daten-filter/README.md
@@ -1,6 +1,6 @@
 # Process Ist Daten Tool
 
-- CLI tools used to manipulate [Ist-Daten](https://opentransportdata.swiss/de/cookbook/actual-data/) dataset
+- CLI tools used to manipulate [Ist-Daten](https://archive.opentransportdata.swiss/actual_data_archive.htm) dataset
 - see [CHANGELOG](./CHANGELOG.md) for latest changes
 
 ## Scripts


### PR DESCRIPTION
- `tools/atlas-geocode-lines`: adds override atlas-lines description
- `apps/atlas-routes-compare-gtfs`: adds GUI filter support for slnid
- `apps/gtfs-query`:  adds `service_day` support for `query_routes_representative_trip` query