### PR TITLE
Improve GTFS-RT static comparison

### DIFF
--- a/apps/gtfs-rt-static-report/src/app/app.component.html
+++ b/apps/gtfs-rt-static-report/src/app/app.component.html
@@ -23,6 +23,11 @@
 
       <div class="mx-2"></div>
 
+      <div class="form-check">
+        <input class="form-check-input" type="checkbox" id="showAllHours" [(ngModel)]="this.model.showAllHours" (ngModelChange)="onClickShowAllHours()" />
+        <label class="form-check-label" for="showAllHours">Show All Hours</label>
+      </div>
+
       <div class="ms-auto p-2"><a href="https://github.com/openTdataCH/OJP-Showcase/blob/develop/tools/gtfs-rt-static-compare/docs/gtfs-rt-static-compare.md" target="_blank">Documentation</a></div>
     </div>
 

--- a/apps/gtfs-rt-static-report/src/app/app.component.html
+++ b/apps/gtfs-rt-static-report/src/app/app.component.html
@@ -1,124 +1,164 @@
-<div class="container-fluid d-flex flex-column vh-100">
-  <header class="row page-row">
-    <div class="col-12">
-      <h2>GTFS-RT - GTFS static Report</h2>
-    </div>
+<div class="d-flex flex-column vh-100 overflow-hidden">
+  <header class="p-3">
+    <h2>GTFS-RT - GTFS static Report</h2>
   </header>
 
-  <main class="row page-row flex-fill">
-    <div class="col-10">
-      <div class="d-flex flex-row align-items-center mb-2">
-        <label for="monthSelect">Choose Month</label>
-        <div class="mx-2">
-          <select class="form-control" id="monthSelect" [(ngModel)]="this.model.selectedMonth" (ngModelChange)="onMonthSelectChange()">
-            <option *ngFor="let monthItem of this.model.monthItems" [ngValue]="monthItem">{{ monthItem }}</option>
-          </select>
-        </div>
-        
-        <div class="mx-2"></div>
-        
-        <label for="reportValueTypeSelect">Choose Cell Value</label>
-        <div class="mx-2">
-          <select class="form-control" id="reportValueTypeSelect" [(ngModel)]="this.model.selectedReportValueLookup" (ngModelChange)="onReportValueTypeChange()">
-            <option *ngFor="let reportValueLookup of this.model.reportValueLookups" [ngValue]="reportValueLookup">{{ reportValueLookup.caption }}</option>
-          </select>
-        </div>
-
-        <div class="ms-auto p-2"><a href="https://github.com/openTdataCH/OJP-Showcase/blob/develop/tools/gtfs-rt-static-compare/docs/gtfs-rt-static-compare.md" target="_blank">Documentation</a></div>
+  <div class="flex-grow-1 d-flex flex-column overflow-hidden pt-3 ps-3 pe-3">
+    <div class="d-flex flex-row align-items-center">
+      <label for="monthSelect">Month</label>
+      <div class="mx-2">
+        <select class="form-control" id="monthSelect" [(ngModel)]="this.model.selectedMonth" (ngModelChange)="onMonthSelectChange()">
+          <option *ngFor="let monthItem of this.model.monthItems" [ngValue]="monthItem">{{ monthItem }}</option>
+        </select>
+      </div>
+      
+      <div class="mx-2"></div>
+      
+      <label for="reportValueTypeSelect">Cell Value</label>
+      <div class="mx-2">
+        <select class="form-control" id="reportValueTypeSelect" [(ngModel)]="this.model.selectedReportValueLookup" (ngModelChange)="onReportValueTypeChange()">
+          <option *ngFor="let reportValueLookup of this.model.reportValueLookups" [ngValue]="reportValueLookup">{{ reportValueLookup.caption }}</option>
+        </select>
       </div>
 
-      <table class="table table-bordered report mb-2">
-        <thead>
-          <tr>
-            <th scope="col">Day-Hr</th>
-            <th *ngFor="let hourCell of this.model.hourCells" class="text-center">{{ hourCell.hourF }}</th>
-          </tr>
-        </thead>
-        <tbody class="table-group-divider">
-          <tr class="align-middle"
-            *ngFor="let dayCell of this.model.dayCells; index as dayIdx">
-            <th scope="row"[ngClass]="{'separator': dayCell.isSunday}">{{ dayCell.dateF }}</th>
-            <td *ngFor="let reportCell of this.model.monthlyHoursReport[dayIdx]; index as hrIdx"
-              [ngClass]="{'selected': reportCell === this.model.selectedReportCell, 'separator': reportCell.dayCell.isSunday}"
-              (click)="this.model.selectedReportCell = reportCell"
-              class="{{ reportCell.className }} text-center">
-              <div class="d-flex flex-column">
-                <div>{{ reportCell.cellValue }}</div>
-                <div class="cell_error"><span class="badge rounded-pill text-bg-danger">{{ reportCell.error }}</span></div>
-              </div>
-            </td>
-          </tr>
-        </tbody>
-      </table>
+      <div class="mx-2"></div>
 
-      <div>Report Last Update: {{ this.model.reportJSON?.last_update_dt }}</div>
+      <div class="ms-auto p-2"><a href="https://github.com/openTdataCH/OJP-Showcase/blob/develop/tools/gtfs-rt-static-compare/docs/gtfs-rt-static-compare.md" target="_blank">Documentation</a></div>
     </div>
 
-    <div class="col-2 right-column">
-      <div *ngIf="this.model.selectedReportCell !== null">
-        <p class="h5">Report {{ this.model.selectedReportCell.dayCell.dateF }} {{ this.model.selectedReportCell.hourCell.hourF }}:00</p>
-        <hr/>
-        <table class="table">
+    <hr/>
+
+    <div class="d-flex overflow-auto mb-1">
+      <!-- Left-side column (table) -->
+      <div #scrollContainer class="flex-grow-1 overflow-auto d-flex">
+        <table class="table table-bordered table-hover report">
           <thead>
-            <tr>
-              <th scope="col">Key</th>
-              <th scope="col">Value</th>
+            <tr class="week-separator">
+              <th class="sticky-col table-top align-middle col-freeze-separator">Day-Hr</th>
+              <ng-container *ngFor="let hourCell of this.model.hourCells">
+                <th scope="col" class="text-center align-middle">{{ hourCell.hourF }}</th>
+              </ng-container>
             </tr>
           </thead>
+
           <tbody>
-            <tr>
-              <th scope="row">Report URL</th>
-              <td><a [href]="computeReportURL()" target="_blank">{{ this.model.selectedReportCell.report?.report_dt }}</a></td>
-            </tr>
-            <tr>
-              <th scope="row">GTFS-DB</th>
-              <td><a href="https://tools.odpch.ch/gtfs-static-dbs/gtfs-static-dbs.json" target="_blank">{{ this.model.selectedReportCell.report?.gtfs_db_filename }}</a></td>
-            </tr>
-            <tr>
-              <th scope="row">{{ computeDetailLookupCaption('gtfs_db_age') }}</th>
-              <td>{{ computeDetailLookupValue('gtfs_db_age') }} days</td>
-            </tr>
-            <tr>
-              <th scope="row">GTFS-RT (large file!)</th>
-              <td><a [href]="computeGTFS_RT_URL(this.model.selectedReportCell.report)" target="_blank">{{ this.model.selectedReportCell.report?.gtfs_rt_filename }}</a></td>
-            </tr>
-            <tr>
-              <th scope="row">{{ computeDetailLookupCaption('gtfs_rt_age') }}</th>
-              <td>{{ computeDetailLookupValue('gtfs_rt_age') }}"</td>
-            </tr>
-            <tr>
-              <th scope="row">{{ computeDetailLookupCaption('total_rows_no') }}</th>
-              <td>{{ computeDetailLookupValue('total_rows_no') }}</td>
-            </tr>
-            <tr>
-              <th scope="row">{{ computeDetailLookupCaption('tripOK_routeOK_no') }}</th>
-              <td>{{ computeDetailLookupValue('tripOK_routeOK_no') }}</td>
-            </tr>
-            <tr>
-              <th scope="row">{{ computeDetailLookupCaption('tripOK_routeNOK_no') }}</th>
-              <td>{{ computeDetailLookupValue('tripOK_routeNOK_no') }}</td>
-            </tr>
-            <tr>
-              <th scope="row">{{ computeDetailLookupCaption('tripNOK_routeOK_no') }}</th>
-              <td>{{ computeDetailLookupValue('tripNOK_routeOK_no') }}</td>
-            </tr>
-            <tr>
-              <th scope="row">{{ computeDetailLookupCaption('tripNOK_routeNOK_no') }}</th>
-              <td>{{ computeDetailLookupValue('tripNOK_routeNOK_no') }}</td>
-            </tr>
-            <tr>
-              <th scope="row">{{ computeDetailLookupCaption('tripNOK_NOJP_no') }}</th>
-              <td>{{ computeDetailLookupValue('tripNOK_NOJP_no') }}</td>
-            </tr>
+            <ng-container *ngFor="let dayCell of this.model.dayCells; index as dayIdx">
+              <tr class="align-middle" [ngClass]="{'week-separator': dayCell.isSunday}" [attr.id]="'row-' + dayCell.dayF">
+                <th class="sticky-col col-freeze-separator" scope="row">{{ dayCell.dateF }}</th>
+                
+                <ng-container *ngFor="let reportCell of this.model.hourlyReportCells[dayIdx]; index as hrIdx">
+
+                  <td 
+                    [ngClass]="{
+                      'selected': reportCell === this.model.selectedReportCell, 
+                      'week-separator': reportCell.dayCell.isSunday,
+                      'prev_data': this.model.selectedReportMapPrevKeys[reportCell.key],
+                    }" 
+                    (click)="this.updateSelection(reportCell)"
+                    class="{{ reportCell.className }} text-center"
+                  >
+                    <div class="d-flex flex-column">
+                      <div>{{ reportCell.cellValue }}</div>
+                      <div class="cell_error"><span class="badge rounded-pill text-bg-danger">{{ reportCell.error }}</span></div>
+                    </div>
+                  </td>
+                </ng-container>
+              </tr>
+            </ng-container>
           </tbody>
         </table>
+      </div>
+      
+      <!-- Right-side column (details) -->
+      <div class="details p-2 d-flex flex-column">
+        <ng-container *ngIf="this.model.selectedReportCell !== null">
+          <p class="h5 mb-1">Report {{ this.model.selectedReportCell.dayCell.dateF }} {{ this.model.selectedReportCell.hourCell.hourF }}:00</p>
+          
+          <hr/>
 
-        <div>
-          Detail Report:<br/><a [href]="computeDetailReportURL()" target="_blank">tools.odpch.ch/gtfs-rt-status</a>
-        </div>
+          <div class="flex-grow-1 overflow-auto">
+            <table class="table table-hover">
+              <tbody>
+                <tr>
+                  <th scope="row">Report URL</th>
+                  <td><a [href]="computeReportURL()" target="_blank">{{ this.model.selectedReportCell.report?.report_dt }}</a></td>
+                </tr>
+                <tr>
+                  <th scope="row">GTFS-DB</th>
+                  <td><a href="https://tools.odpch.ch/gtfs-static-dbs/gtfs-static-dbs.json" target="_blank">{{ this.model.selectedReportCell.report?.gtfs_db_filename }}</a></td>
+                </tr>
+                <tr>
+                  <th scope="row">{{ computeDetailLookupCaption('gtfs_db_age') }}</th>
+                  <td>{{ computeDetailLookupValue('gtfs_db_age') }} days</td>
+                </tr>
+                <tr>
+                  <th scope="row">GTFS-RT (large file!)</th>
+                  <td><a [href]="computeGTFS_RT_URL(this.model.selectedReportCell.report)" target="_blank">{{ this.model.selectedReportCell.report?.gtfs_rt_filename }}</a></td>
+                </tr>
+                <tr>
+                  <th scope="row">{{ computeDetailLookupCaption('gtfs_rt_age') }}</th>
+                  <td>{{ computeDetailLookupValue('gtfs_rt_age') }}"</td>
+                </tr>
+                <tr>
+                  <th scope="row">{{ computeDetailLookupCaption('total_rows_no') }}</th>
+                  <td>{{ computeDetailLookupValue('total_rows_no') }}</td>
+                </tr>
+                <!-- TODO - fix the -1 hack -->
+                <ng-container *ngIf="this.model.selectedReportCell.compareMetadata?.meanValueF !== '-1'">
+                  <tr>
+                    <th scope="row">Previous Total Trips</th>
+                    <td>
+                      <div>
+                        <strong>Value:</strong> {{ this.model.selectedReportCell.compareMetadata?.valueF }}
+                      </div>
+                      <div>
+                        <strong>Mean:</strong> {{ this.model.selectedReportCell.compareMetadata?.meanValueF }}
+                      </div>
+                      <div>
+                        <strong>DropLine:</strong> {{ this.model.selectedReportCell.compareMetadata?.dropLineF }}
+                      </div>
+                      <hr/>
+                      <ul>
+                        <ng-container *ngFor="let prevDayReportLine of this.model.selectedReportCell.compareMetadata?.reportLines">
+                          <li>{{ prevDayReportLine }}</li>
+                        </ng-container>
+                      </ul>
+                      
+                    </td>
+                  </tr>
+                </ng-container>
+                <tr>
+                  <th scope="row">{{ computeDetailLookupCaption('tripOK_routeOK_no') }}</th>
+                  <td>{{ computeDetailLookupValue('tripOK_routeOK_no') }}</td>
+                </tr>
+                <tr>
+                  <th scope="row">{{ computeDetailLookupCaption('tripOK_routeNOK_no') }}</th>
+                  <td>{{ computeDetailLookupValue('tripOK_routeNOK_no') }}</td>
+                </tr>
+                <tr>
+                  <th scope="row">{{ computeDetailLookupCaption('tripNOK_routeOK_no') }}</th>
+                  <td>{{ computeDetailLookupValue('tripNOK_routeOK_no') }}</td>
+                </tr>
+                <tr>
+                  <th scope="row">{{ computeDetailLookupCaption('tripNOK_routeNOK_no') }}</th>
+                  <td>{{ computeDetailLookupValue('tripNOK_routeNOK_no') }}</td>
+                </tr>
+                <tr>
+                  <th scope="row">{{ computeDetailLookupCaption('tripNOK_NOJP_no') }}</th>
+                  <td>{{ computeDetailLookupValue('tripNOK_NOJP_no') }}</td>
+                </tr>
+              </tbody>
+            </table>
+
+            <div>
+              Detail Report:<br/><a [href]="computeDetailReportURL()" target="_blank">tools.odpch.ch/gtfs-rt-status</a>
+            </div>
+          </div>
+
+        </ng-container>
       </div>
     </div>
-  </main>
+  </div>
 
   <footer class="row page-row">
     <div class="d-flex justify-content-between">

--- a/apps/gtfs-rt-static-report/src/app/app.component.html
+++ b/apps/gtfs-rt-static-report/src/app/app.component.html
@@ -163,6 +163,10 @@
         </ng-container>
       </div>
     </div>
+
+    <hr />
+
+    <div class="mb-3">Report Last Update: {{ this.model.reportLastUpdateF }}</div>
   </div>
 
   <footer class="row page-row">

--- a/apps/gtfs-rt-static-report/src/app/app.component.html
+++ b/apps/gtfs-rt-static-report/src/app/app.component.html
@@ -167,7 +167,7 @@
 
   <footer class="row page-row">
     <div class="d-flex justify-content-between">
-      <div>(c) 2024 Open data platform mobility Switzerland</div>
+      <div>(c) 2024 - 2025 Open data platform mobility Switzerland</div>
       <div>Version: {{ this.model.appVersion }}</div>
     </div>
   </footer>

--- a/apps/gtfs-rt-static-report/src/app/app.component.scss
+++ b/apps/gtfs-rt-static-report/src/app/app.component.scss
@@ -18,8 +18,9 @@ footer {
     margin-bottom: 0px;
 }
 
-.right-column {
-    border-left: 1px dashed #333;
+.details {
+    font-size: 14px;
+    width: 420px;
 }
 
 .report {
@@ -34,11 +35,54 @@ footer {
     background-color: #ADD8E6;
 }
 
-.selected {
+$cell-min-w: 72px;
+$cell-h: 64px;
+
+table.report {
+    width: max(100%, calc(#{$cell-min-w} * 25)); // 1 day col + 24 hour cols
+}
+
+// all cells
+.table > :not(caption) > * > * {
+    min-width: $cell-min-w;
+    height: $cell-h;
+    border: 1px solid rgba(0,0,0,.1);
+}
+
+// Separators, override border
+.table > :not(caption) > tr.week-separator > * {
+    border-bottom: 2px solid #515151;
+}
+.table > :not(caption) > tr > .col-freeze-separator {
+    border-right: 2px solid #515151;
+}
+
+// Selected cells
+.table > :not(caption) > tr > td.selected {
     border-width: 3px;
     border-color: #0047AB;
 }
 
-.separator {
-    border-bottom: 2px solid #515151;
+// PrevData cells
+.table > :not(caption) > tr > td.prev_data {
+    border-width: 2px;
+    border-color: #731dca;
+    border-style: dashed;
+}
+
+// Sticky header
+.report thead th {
+    position: sticky;
+    top: 0;
+}
+
+// Sticky first column
+.sticky-col {
+    position: sticky;
+    left: 0;
+}
+
+// Table elements always on top (z-index)
+.table-top {
+    z-index: 2;
 }

--- a/apps/gtfs-rt-static-report/src/app/app.component.ts
+++ b/apps/gtfs-rt-static-report/src/app/app.component.ts
@@ -544,4 +544,9 @@ export class AppComponent {
 
     row.scrollIntoView({ behavior: 'auto', block: 'nearest' });
   }
+
+  public updateSelection(reportCell: ReportCell) {
+    this.model.selectedReportCell = reportCell;
+    this.updatePrevDaysModel();
+  }
 }

--- a/apps/gtfs-rt-static-report/src/app/app.component.ts
+++ b/apps/gtfs-rt-static-report/src/app/app.component.ts
@@ -395,35 +395,40 @@ export class AppComponent {
 
     this.model.hourlyReportCells = dayReportCells;
     this.model.dayCells = dayCells;
+  }
 
-    this.model.selectedReportCell = (() => {
-      const nowDayIdx = (() => {
-        if (isSameMonth) {
-          // use current day for current month
-          const nowDay = new Date().getDate();
-          return nowDay - 1;
+  private updateSelectionByDayHr(reportYMDH: string | null = null) {
+    const allReports = this.model.hourlyReportCells.flat();
+    const latestReportCell = allReports.reverse().find(el => (el.report !== null)) ?? null;
+    if (latestReportCell === null) {
+      // return early
+      return;
+    }
+
+    if (reportYMDH === null) {
+      // use latest available report
+      this.model.selectedReportCell = latestReportCell;
+    } else {
+      const ymd = reportYMDH.substring(0, 10);
+      const dayReportCells = allReports.filter(el => (el.dayCell.dayF === ymd));
+
+      if (dayReportCells.length === 0) {
+        // no reports for given day, defaults to latest available report
+        this.model.selectedReportCell = latestReportCell;
+      } else {
+        const hrF = reportYMDH.substring(11, 13);
+        const hrReport = dayReportCells.find(el => (el.hourCell.hourF === hrF)) ?? null;
+        
+        if (hrReport === null) {
+          // the hr couldnt be found, display first for the given day
+          this.model.selectedReportCell = dayReportCells[0];
         } else {
-          // otherwise use first day of month
-          return 0;
+          this.model.selectedReportCell = hrReport;
         }
-      })();
-
-      const hourReportRows = dayReportCells[nowDayIdx] ?? null;
-      if (hourReportRows === null) {
-        return null;
       }
+    }
 
-      // filter for non-null reports
-      const hourReportNotNullRows = hourReportRows.filter(el => el.report !== null);
-      if (hourReportNotNullRows.length === 0) {
-        return null;
-      }
 
-      const cellIndex = (() => {
-        if (isSameMonth) {
-          // for current month use latest report
-          return hourReportNotNullRows.length - 1;
-        }
 
         return 0;
       })();

--- a/apps/gtfs-rt-static-report/src/app/app.component.ts
+++ b/apps/gtfs-rt-static-report/src/app/app.component.ts
@@ -71,7 +71,7 @@ interface ReportCell {
 }
 
 interface PageModel {
-  reportJSON: GTFS_RT_Static_Monthly_Report_JSON | null
+  mapMonthlyReports: Record<string, GTFS_RT_Static_Monthly_Report_JSON>
   monthItems: string[],
   selectedMonth: string,
   monthlyHoursReport: ReportCell[][],

--- a/apps/gtfs-rt-static-report/src/app/app.component.ts
+++ b/apps/gtfs-rt-static-report/src/app/app.component.ts
@@ -152,16 +152,17 @@ export class AppComponent {
 
   constructor(private dataService: DataService) {
     this.model = {
-      reportJSON: null,
+      mapMonthlyReports: {},
       monthItems: monthItems,
       selectedMonth: monthItems[0],
-      monthlyHoursReport: [],
+      hourlyReportCells: [],
       selectedReportCell: null,
       dayCells: [],
       hourCells: [],
       reportValueLookups: reportValueLookups,
       selectedReportValueLookup: reportValueLookups[0],
       appVersion: '2024-06-03-1'
+      showAllHours: false,
     this.updateHourCells();
 
   private updateHourCells() {

--- a/apps/gtfs-rt-static-report/src/app/app.component.ts
+++ b/apps/gtfs-rt-static-report/src/app/app.component.ts
@@ -236,24 +236,13 @@ export class AppComponent {
   }
 
   private updateReportModel() {
-    if (this.model.reportJSON === null) {
+    const latestReport = this.model.mapMonthlyReports[this.model.selectedMonth] ?? null;
+
+    if (latestReport === null) {
       return;
     }
 
-    const reportLastUpdate = new Date(this.model.reportJSON.last_update_dt);
-    const report = this.model.reportJSON;
-
-    const currentDateParts = this.model.selectedMonth.split('-');
-    const currentDateYear = Number(currentDateParts[0]);
-    const currentDateMonth = Number(currentDateParts[1]);
-
-    const nowDate = new Date();
-    const nowHHMM = nowDate.toTimeString().substring(0, 5);
-
-    const monthDay1Date = new Date(this.model.selectedMonth + '-01');
-    const selectedMonthDaysNo = DateHelpers.computeMonthDaysNo(monthDay1Date);
-
-    const isSameMonth = DateHelpers.isSameMonth(monthDay1Date);
+    const reportLastUpdate = new Date(latestReport.last_update_dt);
     this.model.reportLastUpdateF = latestReport.last_update_dt;
 
     const dayReportCells: ReportCell[][] = [];
@@ -262,102 +251,121 @@ export class AppComponent {
     let classDBSource: CellClassDB = 'odd';
     let prevDBName: string | null = null;
 
-    let currentDay = 1;
-    while (currentDay <= selectedMonthDaysNo) {
-      const dayCell: DayCell = (() => {
-        const currentDayDate = new Date(currentDateYear, currentDateMonth - 1, currentDay);
-        let currentDayF = currentDayDate.toLocaleDateString('en-US', {
-          weekday: 'short',
-          day: '2-digit',
-          month: 'short',
-        });
-        currentDayF = currentDayF.replace(',', '');
-        const currentDayFParts = currentDayF.split(' ');
-        currentDayF = currentDayFParts[0] + ' ' + currentDayFParts[2] + '.' + currentDayFParts[1].replace(',', '');
-        const isSunday = currentDayFParts[0] === 'Sun';
+    for (const reportYM in this.model.mapMonthlyReports) {
+      const report = this.model.mapMonthlyReports[reportYM];
 
-        return {
-          date: currentDayDate,
-          dateF: currentDayF,
-          isSunday: isSunday,
-        }
-      })();
+      const monthDay1Date = new Date(reportYM + '-01');
+      const selectedMonthDaysNo = DateHelpers.computeMonthDaysNo(monthDay1Date);
 
-      const dayF = currentDay.toString().padStart(2, '0');
-      const hourReportCells: ReportCell[] = [];
-      const mapDataHourlyReports = report.report_days[dayF] ?? null;
+      const reportYMParts = reportYM.split('-');
+      const reportYearF = Number(reportYMParts[0]);
+      const reportMonthF = Number(reportYMParts[1]);
 
-      hourCells.forEach(hourCell => {
-        const reportCell: ReportCell = {
-          report: null,
-          className: 'ok_empty',
-          cellValue: '',
-          error: null,
-          dayCell: dayCell,
-          hourCell: hourCell,
-        }
+      let currentDay = 1;
+      while (currentDay <= selectedMonthDaysNo) {
+        const dayF = currentDay.toString().padStart(2, '0');
 
-        const hasData: boolean = (() => {
-          const reportCellDateS = this.model.selectedMonth + '-' + dayF + ' ' + hourCell.hourF + ':00:00';
-          const reportCellDate = new Date(reportCellDateS);
+        const dayCell: DayCell = (() => {
+          const currentDayDate = new Date(reportYearF, reportMonthF - 1, currentDay);
+          let currentDayF = currentDayDate.toLocaleDateString('en-US', {
+            weekday: 'short',
+            day: '2-digit',
+            month: 'short',
+          });
+          currentDayF = currentDayF.replace(',', '');
+          const currentDayFParts = currentDayF.split(' ');
+          currentDayF = currentDayFParts[0] + ' ' + currentDayFParts[2] + '.' + currentDayFParts[1].replace(',', '');
+          const isSunday = currentDayFParts[0] === 'Sun';
 
-          const isFuture = reportCellDate > reportLastUpdate;
-          // Discard future event cells
-          if (isFuture) {
-            return false;
+          return {
+            date: currentDayDate,
+            dayF: reportYM + '-' + dayF,
+            dateF: currentDayF,
+            isSunday: isSunday,
           }
-
-          // Otherwise check if we have a report
-          return mapDataHourlyReports !== null;
         })();
 
-        if (hasData) {
-          const hrMinF = hourCell.hourF + '00';
-          const reportHR = mapDataHourlyReports[hrMinF] ?? null;
-          if (reportHR === null) {
-            if (prevDBName !== null) {
-              reportCell.cellValue = 'n/a';
-              reportCell.error = 'DATA';
-            }
-          } else {
-            const reportAny = reportHR as any;
-            const reportValue = reportAny[this.model.selectedReportValueLookup.type] ?? null;
-            if (reportValue === null) {
-              reportCell.cellValue = 'n/a'
-            } else {
-              reportCell.cellValue = reportValue.toLocaleString('de-CH');
-            }
- 
-            if (Math.abs(reportHR.gtfs_rt_age) > 60) {
-              reportCell.error = 'RT age';
-            }
+        const hourReportCells: ReportCell[] = [];
+        const mapDataHourlyReports = report.report_days[dayF] ?? null;
 
-            if (reportHR.tripNOK_NOJP_no > 0) {
-              reportCell.error = 'Match';
-            }
+        this.model.hourCells.forEach(hourCell => {
+          const key = dayCell.dayF + '-' + hourCell.hourF;
 
-            if (prevDBName !== null && (prevDBName !== reportHR.gtfs_db_filename)) {
-              classDBSource = classDBSource === 'odd' ? 'even' : 'odd';
-            }
-            prevDBName = reportHR.gtfs_db_filename;
-
-            reportCell.className = 'ok_' + classDBSource;
+          const reportCell: ReportCell = {
+            key: key,
+            report: null,
+            className: 'ok_empty',
+            cellValue: '',
+            error: null,
+            dayCell: dayCell,
+            hourCell: hourCell,
+            compareMetadata: null,
           }
-          
-          reportCell.report = reportHR;
-        }
 
-        hourReportCells.push(reportCell);
-      });
+          const hasData: boolean = (() => {
+            const reportCellDateS = reportYM + '-' + dayF + ' ' + hourCell.hourF + ':00:00';
+            const reportCellDate = new Date(reportCellDateS);
 
-      dayReportCells.push(hourReportCells);
+            const isFuture = reportCellDate > reportLastUpdate;
+            // Discard future event cells
+            if (isFuture) {
+              return false;
+            }
 
-      dayCells.push(dayCell);
+            // Otherwise check if we have a report
+            return mapDataHourlyReports !== null;
+          })();
 
-      currentDay += 1;
+          if (hasData) {
+            const hrMinF = hourCell.hourF + '00';
+            const reportHR = mapDataHourlyReports[hrMinF] ?? null;
+            if (reportHR === null) {
+              if (prevDBName !== null) {
+                reportCell.cellValue = 'n/a';
+                reportCell.error = 'DATA';
+              }
+            } else {
+              const reportAny = reportHR as any;
+              const reportValue = reportAny[this.model.selectedReportValueLookup.type] ?? null;
+              if (reportValue === null) {
+                reportCell.cellValue = 'n/a'
+              } else {
+                reportCell.cellValue = reportValue.toLocaleString('de-CH');
+              }
+  
+              if (Math.abs(reportHR.gtfs_rt_age) > 60) {
+                reportCell.error = 'RT age';
+              }
+
+              if (reportHR.tripNOK_NOJP_no > 0) {
+                reportCell.error = 'Match';
+              }
+
+              if (prevDBName !== null && (prevDBName !== reportHR.gtfs_db_filename)) {
+                classDBSource = classDBSource === 'odd' ? 'even' : 'odd';
+              }
+              prevDBName = reportHR.gtfs_db_filename;
+
+              reportCell.className = 'ok_' + classDBSource;
+            }
+            
+            reportCell.report = reportHR;
+          }
+
+          if (this.shouldShowHour(hourCell.hour)) {
+            hourReportCells.push(reportCell);
+          }
+        });
+
+        dayReportCells.push(hourReportCells);
+
+        dayCells.push(dayCell);
+
+        currentDay += 1;
+      }
     }
 
-    this.model.monthlyHoursReport = dayReportCells;
+    this.model.hourlyReportCells = dayReportCells;
     this.model.dayCells = dayCells;
 
     this.model.selectedReportCell = (() => {

--- a/apps/gtfs-rt-static-report/src/app/app.component.ts
+++ b/apps/gtfs-rt-static-report/src/app/app.component.ts
@@ -76,7 +76,7 @@ interface PageModel {
   mapMonthlyReports: Record<string, GTFS_RT_Static_Monthly_Report_JSON>
   monthItems: string[],
   selectedMonth: string,
-  monthlyHoursReport: ReportCell[][],
+  hourlyReportCells: ReportCell[][],
   selectedReportCell: ReportCell | null,
   dayCells: DayCell[],
   hourCells: HourCell[],

--- a/apps/gtfs-rt-static-report/src/app/app.component.ts
+++ b/apps/gtfs-rt-static-report/src/app/app.component.ts
@@ -84,6 +84,7 @@ interface PageModel {
   selectedReportValueLookup: ReportValueLookup,
   appVersion: string,
   showAllHours: boolean,
+  reportLastUpdateF: string,
 }
 
 const mapReportValueLookups: Record<ReportValueLookupType, string> = {
@@ -163,6 +164,7 @@ export class AppComponent {
       selectedReportValueLookup: reportValueLookups[0],
       appVersion: '2024-06-03-1'
       showAllHours: false,
+      reportLastUpdateF: 'n/a',
     this.updateHourCells();
 
 
@@ -252,6 +254,7 @@ export class AppComponent {
     const selectedMonthDaysNo = DateHelpers.computeMonthDaysNo(monthDay1Date);
 
     const isSameMonth = DateHelpers.isSameMonth(monthDay1Date);
+    this.model.reportLastUpdateF = latestReport.last_update_dt;
 
     const dayReportCells: ReportCell[][] = [];
     const dayCells: DayCell[] = [];

--- a/apps/gtfs-rt-static-report/src/app/app.component.ts
+++ b/apps/gtfs-rt-static-report/src/app/app.component.ts
@@ -82,7 +82,8 @@ interface PageModel {
   hourCells: HourCell[],
   reportValueLookups: ReportValueLookup[],
   selectedReportValueLookup: ReportValueLookup,
-  appVersion: string
+  appVersion: string,
+  showAllHours: boolean,
 }
 
 const mapReportValueLookups: Record<ReportValueLookupType, string> = {
@@ -141,25 +142,6 @@ const monthItems: string[] = (() => {
   return items.slice().reverse();
 })();
 
-const hourCells: HourCell[] = (() => {
-  const cells: HourCell[] = [];
-
-  let hour = 0;
-  while (hour <= 23) {
-    const hourF = hour.toString().padStart(2, '0');
-
-    const cell: HourCell = {
-      hour: hour,
-      hourF: hourF,
-    };
-    cells.push(cell);
-
-    hour += 1;
-  }
-
-  return cells;
-})();
-
 @Component({
   selector: 'app-root',
   templateUrl: './app.component.html',
@@ -176,11 +158,31 @@ export class AppComponent {
       monthlyHoursReport: [],
       selectedReportCell: null,
       dayCells: [],
-      hourCells: hourCells,
+      hourCells: [],
       reportValueLookups: reportValueLookups,
       selectedReportValueLookup: reportValueLookups[0],
       appVersion: '2024-06-03-1'
+    this.updateHourCells();
+
+  private updateHourCells() {
+    const cells: HourCell[] = [];
+
+    let hour = 0;
+    while (hour <= 23) {
+      const hourF = hour.toString().padStart(2, '0');
+
+      const cell: HourCell = {
+        hour: hour,
+        hourF: hourF,
+      };
+      if (this.shouldShowHour(hour)) {
+        cells.push(cell);
+      }
+
+      hour += 1;
     }
+
+    this.model.hourCells = cells;
   }
 
   ngOnInit() {
@@ -360,8 +362,14 @@ export class AppComponent {
 
       return hourReportNotNullRows[cellIndex];
     })();
+  private shouldShowHour(hour: number) {
+    if (this.model.showAllHours) {
+      return true;
+    }
 
-    console.log(this.model.selectedReportCell);
+    const isNormalHour = (6 <= hour) && (hour <=18);
+    
+    return isNormalHour;
   }
 
   private computeSnapshotURLFromTemplate(templateURL: string, metadata: GTFS_RT_Static_Report_Metadata_JSON) {

--- a/apps/gtfs-rt-static-report/src/app/app.component.ts
+++ b/apps/gtfs-rt-static-report/src/app/app.component.ts
@@ -77,7 +77,10 @@ interface PageModel {
   monthItems: string[],
   selectedMonth: string,
   hourlyReportCells: ReportCell[][],
+  
   selectedReportCell: ReportCell | null,
+  selectedReportMapPrevKeys: Record<string, boolean>,
+  
   dayCells: DayCell[],
   hourCells: HourCell[],
   reportValueLookups: ReportValueLookup[],
@@ -165,6 +168,8 @@ export class AppComponent {
       appVersion: '2024-06-03-1'
       showAllHours: false,
       reportLastUpdateF: 'n/a',
+      selectedReportMapPrevKeys: {},
+    };
     this.updateHourCells();
 
 
@@ -428,13 +433,22 @@ export class AppComponent {
       }
     }
 
+    this.updatePrevDaysModel();
 
 
-        return 0;
-      })();
+  private updatePrevDaysModel() {
+    if (this.model.selectedReportCell === null) {
+      return;
+    }
 
-      return hourReportNotNullRows[cellIndex];
-    })();
+    this.model.selectedReportMapPrevKeys = {};
+    const mapPrevDays = this.model.selectedReportCell.compareMetadata?.info.map_days ?? {};
+    for (const prevDayF in mapPrevDays) {
+      const prevReportKey = prevDayF + '-' + this.model.selectedReportCell.hourCell.hourF;
+      this.model.selectedReportMapPrevKeys[prevReportKey] = true;
+    }
+  }
+
   private shouldShowHour(hour: number) {
     if (this.model.showAllHours) {
       return true;

--- a/apps/gtfs-rt-static-report/src/app/app.component.ts
+++ b/apps/gtfs-rt-static-report/src/app/app.component.ts
@@ -4,6 +4,7 @@ import { DateHelpers } from './helpers/date-helpers';
 
 interface DayCell {
   date: Date,
+  dayF: string,
   dateF: string,
   isSunday: boolean
 }

--- a/apps/gtfs-rt-static-report/src/app/app.component.ts
+++ b/apps/gtfs-rt-static-report/src/app/app.component.ts
@@ -1,4 +1,4 @@
-import { Component } from '@angular/core';
+import { Component, ElementRef, ViewChild } from '@angular/core';
 import { DataService } from './data.service';
 import { DateHelpers } from './helpers/date-helpers';
 
@@ -153,6 +153,8 @@ const monthItems: string[] = (() => {
 })
 export class AppComponent {
   public model: PageModel;
+
+  @ViewChild('scrollContainer') scrollContainer!: ElementRef;
 
   constructor(private dataService: DataService) {
     this.model = {
@@ -435,6 +437,9 @@ export class AppComponent {
 
     this.updatePrevDaysModel();
 
+    const dayF = this.model.selectedReportCell.dayCell.dayF;
+    this.scrollToDay(dayF);
+  }
 
   private updatePrevDaysModel() {
     if (this.model.selectedReportCell === null) {
@@ -526,5 +531,14 @@ export class AppComponent {
     const url = 'https://tools.odpch.ch/gtfs-rt-status/?report=' + metadata.gtfs_rt_filename;
 
     return url;
+  }
+
+  public scrollToDay(ymd: string) {
+    const row = this.scrollContainer.nativeElement.querySelector(`#row-${ymd}`) ?? null;
+    if (row === null) {
+      return;
+    }
+
+    row.scrollIntoView({ behavior: 'auto', block: 'nearest' });
   }
 }

--- a/apps/gtfs-rt-static-report/src/app/app.component.ts
+++ b/apps/gtfs-rt-static-report/src/app/app.component.ts
@@ -2,12 +2,6 @@ import { Component } from '@angular/core';
 import { DataService } from './data.service';
 import { DateHelpers } from './helpers/date-helpers';
 
-interface GTFS_RT_Static_Monthly_Report_JSON {
-  last_update_dt: string
-  comments: string
-  report_days: Record<string, Record<string, GTFS_RT_Static_Report_Metadata_JSON>>
-}
-
 interface DayCell {
   date: Date,
   dateF: string,
@@ -42,7 +36,13 @@ interface GTFS_RT_Static_Report_Metadata_JSON {
   tripNOK_NOJP_no: number
 }
 
-type CellClassDB = 'odd' | 'even'
+export interface GTFS_RT_Static_Monthly_Report_JSON {
+  last_update_dt: string
+  comments: string
+  report_days: Record<string, Record<string, GTFS_RT_Static_Report_Metadata_JSON>>
+}
+
+type CellClassDB = 'odd' | 'even';
 
 interface ReportCell {
   report: GTFS_RT_Static_Report_Metadata_JSON | null

--- a/apps/gtfs-rt-static-report/src/app/app.component.ts
+++ b/apps/gtfs-rt-static-report/src/app/app.component.ts
@@ -223,10 +223,10 @@ export class AppComponent {
     this.updateReportModel();
   }
 
+  public async onMonthSelectChange() {
+    await this.fetchAndUpdateReport();
   }
 
-  public onMonthSelectChange() {
-    this.fetchAndUpdateReport();
   }
 
   public onReportValueTypeChange() {

--- a/apps/gtfs-rt-static-report/src/app/app.component.ts
+++ b/apps/gtfs-rt-static-report/src/app/app.component.ts
@@ -62,6 +62,7 @@ interface GTFS_RT_StaticReportCompareMetadata {
 }
 
 interface ReportCell {
+  key: string
   report: GTFS_RT_Static_Report_Metadata_JSON | null
   className: string
   cellValue: string

--- a/apps/gtfs-rt-static-report/src/app/app.component.ts
+++ b/apps/gtfs-rt-static-report/src/app/app.component.ts
@@ -36,13 +36,29 @@ interface GTFS_RT_Static_Report_Metadata_JSON {
   tripNOK_NOJP_no: number
 }
 
+interface GTFS_RT_Static_Report_Compare_JSON {
+  compare_type: 'h' | 'w' | 'w_p'
+  map_days: Record<string, number>
+  mean_value: Number
+  drop_line: Number
+}
+
 export interface GTFS_RT_Static_Monthly_Report_JSON {
   last_update_dt: string
   comments: string
   report_days: Record<string, Record<string, GTFS_RT_Static_Report_Metadata_JSON>>
+  compare_days: Record<string, Record<string, GTFS_RT_Static_Report_Compare_JSON>>
 }
 
 type CellClassDB = 'odd' | 'even';
+
+interface GTFS_RT_StaticReportCompareMetadata {
+  info: GTFS_RT_Static_Report_Compare_JSON
+  reportLines: string[]
+  valueF: string
+  meanValueF: string
+  dropLineF: string
+}
 
 interface ReportCell {
   report: GTFS_RT_Static_Report_Metadata_JSON | null
@@ -51,6 +67,7 @@ interface ReportCell {
   error: string | null
   dayCell: DayCell,
   hourCell: HourCell,
+  compareMetadata: GTFS_RT_StaticReportCompareMetadata | null,
 }
 
 interface PageModel {

--- a/apps/gtfs-rt-static-report/src/app/app.component.ts
+++ b/apps/gtfs-rt-static-report/src/app/app.component.ts
@@ -165,6 +165,16 @@ export class AppComponent {
       showAllHours: false,
     this.updateHourCells();
 
+
+  async ngOnInit(): Promise<void> {
+    await this.fetchAndUpdateReport();
+    
+    // HACK setTimeout with 0, otherwise doesnt scroll, the scroll scrollContainer is not ready
+    setTimeout(() => {
+      this.updateSelectionByDayHr();
+    }, 0);
+  }
+
   private updateHourCells() {
     const cells: HourCell[] = [];
 
@@ -186,15 +196,33 @@ export class AppComponent {
     this.model.hourCells = cells;
   }
 
-  ngOnInit() {
-    this.fetchAndUpdateReport();
+  private async fetchAndUpdateReport() {
+    this.model.mapMonthlyReports = {};
+
+    const prevMonthF: string = (() => {
+      const monthParts = this.model.selectedMonth.split('-');
+      let prevYear = Number(monthParts[0]);
+      let prevMonth = Number(monthParts[1]) - 1;
+      if (prevMonth === 0) {
+        prevYear -= 1;
+        prevMonth = 12;
+      }
+
+      const prevYearF = String(prevYear).padStart(2, '0');
+      const prevMonthF = String(prevMonth).padStart(2, '0');
+
+      return prevYearF + '-' + prevMonthF;
+    })();
+
+    const prevMonthReport = await this.dataService.getMonthlyReport(prevMonthF);
+    this.model.mapMonthlyReports[prevMonthF] = prevMonthReport
+
+    const currentMonthReport = await this.dataService.getMonthlyReport(this.model.selectedMonth);
+    this.model.mapMonthlyReports[this.model.selectedMonth] = currentMonthReport;
+
+    this.updateReportModel();
   }
 
-  private fetchAndUpdateReport() {
-    this.dataService.getMonthlyReport(this.model.selectedMonth).subscribe((response) => {
-      this.model.reportJSON = response;
-      this.updateReportModel();
-    });
   }
 
   public onMonthSelectChange() {

--- a/apps/gtfs-rt-static-report/src/app/app.component.ts
+++ b/apps/gtfs-rt-static-report/src/app/app.component.ts
@@ -167,7 +167,7 @@ export class AppComponent {
       hourCells: [],
       reportValueLookups: reportValueLookups,
       selectedReportValueLookup: reportValueLookups[0],
-      appVersion: '2024-06-03-1'
+      appVersion: '20250905.1',
       showAllHours: false,
       reportLastUpdateF: 'n/a',
       selectedReportMapPrevKeys: {},

--- a/apps/gtfs-rt-static-report/src/app/app.component.ts
+++ b/apps/gtfs-rt-static-report/src/app/app.component.ts
@@ -347,6 +347,34 @@ export class AppComponent {
               prevDBName = reportHR.gtfs_db_filename;
 
               reportCell.className = 'ok_' + classDBSource;
+
+              if (dayF in report.compare_days) {
+                if (hrMinF in report.compare_days[dayF]) {
+                  const compare_info = report.compare_days[dayF][hrMinF];
+
+                  const prevValues: Number[] = [];
+                  const compareReportLines: string[] = [];
+                  for (const dayF in compare_info.map_days) {
+                    const prevValue = compare_info.map_days[dayF];
+                    prevValues.push(prevValue);
+                    const compareReportLine = dayF + ': ' + prevValue;
+                    compareReportLines.push(compareReportLine);
+                  }
+
+                  const compareMetadata: GTFS_RT_StaticReportCompareMetadata = {
+                    info: compare_info,
+                    reportLines: compareReportLines,
+                    valueF: '' + (reportAny['total_rows_no'] ?? 0),
+                    meanValueF: '' + compare_info.mean_value,
+                    dropLineF: '' + compare_info.drop_line,
+                  };
+
+                  reportCell.compareMetadata = compareMetadata;
+                  if (compare_info.compare_type === 'w_p') {
+                    reportCell.error = 'Drop';
+                  }
+                }
+              }
             }
             
             reportCell.report = reportHR;

--- a/apps/gtfs-rt-static-report/src/app/app.component.ts
+++ b/apps/gtfs-rt-static-report/src/app/app.component.ts
@@ -236,6 +236,9 @@ export class AppComponent {
     await this.fetchAndUpdateReport();
   }
 
+  public onClickShowAllHours() {
+    this.updateHourCells();
+    this.updateReportModel();
   }
 
   public onReportValueTypeChange() {

--- a/apps/gtfs-rt-static-report/src/app/app.component.ts
+++ b/apps/gtfs-rt-static-report/src/app/app.component.ts
@@ -86,7 +86,7 @@ interface PageModel {
 const mapReportValueLookups: Record<ReportValueLookupType, string> = {
   gtfs_db_age: 'GTFS-DB Age',
   gtfs_rt_age: 'GTFS-RT Age',
-  total_rows_no: 'GTFS-RT Trips',
+  total_rows_no: 'GTFS-RT Total Trips No',
   tripOK_routeOK_no: 'Matched Trips',
   tripOK_routeNOK_no: 'Matched Trips / Not-matched Routes',
   tripNOK_routeOK_no: 'Not-matched Trips / Matched Routes',

--- a/apps/gtfs-rt-static-report/src/app/data.service.ts
+++ b/apps/gtfs-rt-static-report/src/app/data.service.ts
@@ -1,6 +1,8 @@
 import { HttpClient } from '@angular/common/http';
 import { Injectable } from '@angular/core';
-import { Observable } from 'rxjs';
+import { firstValueFrom } from 'rxjs';
+
+import { GTFS_RT_Static_Monthly_Report_JSON } from './app.component';
 
 @Injectable({
   providedIn: 'root'
@@ -9,15 +11,15 @@ export class DataService {
 
   constructor(private http: HttpClient) { }
 
-  getMonthlyReport(dateYM: string): Observable<any> {
+  async getMonthlyReport(dateYM: string): Promise<GTFS_RT_Static_Monthly_Report_JSON> {
     const dateYMParts = dateYM.split('-');
 
     const now = new Date();
 
-    let API_ENDPOINT = 'https://tools.odpch.ch/gtfs-rt-static-compare-report/[YYYY]/gtfs_rt_static_report-[YYYY-MM].json?ts=' + now.getTime();
-    API_ENDPOINT = API_ENDPOINT.replace('[YYYY]', dateYMParts[0]);
-    API_ENDPOINT = API_ENDPOINT.replace('[YYYY-MM]', dateYM);
+    let url = 'https://tools.odpch.ch/gtfs-rt-static-compare-report/[YYYY]/gtfs_rt_static_report-[YYYY-MM].json?ts=' + now.getTime();
+    url = url.replace('[YYYY]', dateYMParts[0]);
+    url = url.replace('[YYYY-MM]', dateYM);
     
-    return this.http.get(API_ENDPOINT);
+    return await firstValueFrom(this.http.get<GTFS_RT_Static_Monthly_Report_JSON>(url));
   }
 }

--- a/tools/_shared/inc/helpers/config_helpers.py
+++ b/tools/_shared/inc/helpers/config_helpers.py
@@ -48,5 +48,6 @@ def load_env_vars(dotenv_path: Path) -> None:
     local_dotenv_path = f'{dotenv_path}.local'
     if os.path.exists(local_dotenv_path):
         file_to_load_path = local_dotenv_path
+        
+    load_dotenv(dotenv_path=file_to_load_path, override=True)
     
-    load_dotenv(dotenv_path=file_to_load_path)

--- a/tools/_shared/inc/helpers/log_helpers.py
+++ b/tools/_shared/inc/helpers/log_helpers.py
@@ -23,3 +23,7 @@ def log_message(message: str):
         message = f'{message} - {memory_message}'
     
     print(message)
+    
+def format_path(path: str, app_path: str):
+    new_path = path.replace(app_path, '.')
+    return new_path

--- a/tools/_shared/inc/models/gtfs_rt.py
+++ b/tools/_shared/inc/models/gtfs_rt.py
@@ -28,10 +28,31 @@ class Header:
   
     @staticmethod
     def from_gtfs_rt_json(json_data: dict):
+        gtfsRealtimeVersion_value = read_safe_json_key(json_data, 'GtfsRealtimeVersion')
+        if gtfsRealtimeVersion_value is None:
+            print('ERROR - Header.from_gtfs_rt_json - GtfsRealtimeVersion cant be None')
+            print(json_data)
+            sys.exit()
+        
+        incrementality_value = read_safe_json_key(json_data, 'Incrementality')
+        if incrementality_value is None:
+            print('ERROR - Header.from_gtfs_rt_json - Incrementality cant be None')
+            print(json_data)
+            sys.exit()
+        
+        timestamp_value = read_safe_json_key(json_data, 'Timestamp')
+        if timestamp_value is None:
+            print('ERROR - Header.from_gtfs_rt_json - Timestamp cant be None')
+            print(json_data)
+            sys.exit()
+        
+        # backend might return strings
+        timestamp_value = int(timestamp_value)
+        
         header = Header(
-            gtfsRealtimeVersion=json_data['GtfsRealtimeVersion'],
-            incrementality=json_data['Incrementality'],
-            timestamp=json_data['Timestamp'],
+            gtfsRealtimeVersion=gtfsRealtimeVersion_value,
+            incrementality=incrementality_value,
+            timestamp=timestamp_value,
         )
         
         return header
@@ -45,9 +66,9 @@ class StopTime:
     @staticmethod
     def from_gtfs_rt_json(json_data: dict):
         stopTime = StopTime()
-        stopTime.delay = json_data.get('Delay', None)
-        stopTime.time = json_data.get('Time', None)
-        stopTime.scheduleRelationship = json_data.get('ScheduleRelationship', None)
+        stopTime.delay = read_safe_json_key(json_data, 'Delay')
+        stopTime.time = read_safe_json_key(json_data, 'Time')
+        stopTime.scheduleRelationship = read_safe_json_key(json_data, 'ScheduleRelationship')
 
         return stopTime
   
@@ -61,20 +82,37 @@ class StopTimeUpdate:
     
     @staticmethod
     def from_gtfs_rt_json(json_data):
-        stopSequence = json_data['StopSequence']
-        stopId = json_data['StopId']
-        scheduleRelationship = json_data['ScheduleRelationship']
+        stopSequence_json = read_safe_json_key(json_data, 'StopSequence')
+        if stopSequence_json is None:
+            print('ERROR - StopTimeUpdate.from_gtfs_rt_json - StopSequence cant be None')
+            print(json_data)
+            sys.exit()
+            
+        stopId_json = read_safe_json_key(json_data, 'StopId')
+        if stopId_json is None:
+            print('ERROR - StopTimeUpdate.from_gtfs_rt_json - StopId cant be None')
+            print(json_data)
+            sys.exit()
+            
+        scheduleRelationship_json = read_safe_json_key(json_data, 'ScheduleRelationship')
+        if scheduleRelationship_json is None:
+            print('ERROR - StopTimeUpdate.from_gtfs_rt_json - ScheduleRelationship cant be None')
+            print(json_data)
+            sys.exit()
 
         stopTimeUpdate = StopTimeUpdate(
-            stopSequence=stopSequence,
-            stopId=stopId,
-            scheduleRelationship=scheduleRelationship,
+            stopSequence=stopSequence_json,
+            stopId=stopId_json,
+            scheduleRelationship=scheduleRelationship_json,
         )
-    
-        if 'Arrival' in json_data:
-            stopTimeUpdate.arrival = StopTime.from_gtfs_rt_json(json_data['Arrival'])
-        if 'Departure' in json_data:
-            stopTimeUpdate.departure = StopTime.from_gtfs_rt_json(json_data['Departure'])
+        
+        arrival_json = read_safe_json_key(json_data, 'Arrival')
+        if arrival_json is not None:
+            stopTimeUpdate.arrival = StopTime.from_gtfs_rt_json(arrival_json)
+            
+        departure_json = read_safe_json_key(json_data, 'Departure')
+        if departure_json is not None:
+            stopTimeUpdate.departure = StopTime.from_gtfs_rt_json(departure_json)
     
         return stopTimeUpdate
   
@@ -85,15 +123,45 @@ class Trip:
     startTime: str
     startDate: str
     scheduleRelationship: str
-    
+      
     @staticmethod
     def from_gtfs_rt_json(json_data: dict):
+        tripId_json = read_safe_json_key(json_data, 'TripId')
+        if tripId_json is None:
+            print('ERROR - Trip.from_gtfs_rt_json - TripId cant be None')
+            print(json_data.keys())
+            sys.exit()
+            
+        routeId_json = read_safe_json_key(json_data, 'RouteId')
+        if routeId_json is None:
+            print('ERROR - Trip.from_gtfs_rt_json - RouteId cant be None')
+            print(json_data.keys())
+            sys.exit()
+            
+        startTime_json = read_safe_json_key(json_data, 'StartTime')
+        if startTime_json is None:
+            print('ERROR - Trip.from_gtfs_rt_json - StartTime cant be None')
+            print(json_data.keys())
+            sys.exit()
+            
+        startDate_json = read_safe_json_key(json_data, 'StartDate')
+        if startDate_json is None:
+            print('ERROR - Trip.from_gtfs_rt_json - StartDate cant be None')
+            print(json_data.keys())
+            sys.exit()
+            
+        scheduleRelationship_json = read_safe_json_key(json_data, 'ScheduleRelationship')
+        if scheduleRelationship_json is None:
+            print('ERROR - Trip.from_gtfs_rt_json - ScheduleRelationship cant be None')
+            print(json_data.keys())
+            sys.exit()
+        
         trip = Trip(
-            tripId=json_data['TripId'],
-            routeId=json_data['RouteId'],
-            startTime=json_data['StartTime'],
-            startDate=json_data['StartDate'],
-            scheduleRelationship=json_data['ScheduleRelationship'],
+            tripId=tripId_json,
+            routeId=routeId_json,
+            startTime=startTime_json,
+            startDate=startDate_json,
+            scheduleRelationship=scheduleRelationship_json,
         )
         
         return trip
@@ -105,10 +173,21 @@ class TripUpdate:
     
     @staticmethod
     def from_gtfs_rt_json(json_data: dict):
-        trip = Trip.from_gtfs_rt_json(json_data['Trip'])
+        trip_json = read_safe_json_key(json_data, 'Trip')
+        if trip_json is None:
+            print('ERROR - TripUpdate.from_gtfs_rt_json - Trip cant be None')
+            print(json_data.keys())
+            sys.exit()
+        
+        trip = Trip.from_gtfs_rt_json(trip_json)
         
         stopTimeUpdates: List[StopTimeUpdate] = []
-        stop_times_update_gtfs_rt_json = json_data.get('StopTimeUpdate', [])
+        stop_times_update_gtfs_rt_json = read_safe_json_key(json_data, 'StopTimeUpdate', [])
+        if stop_times_update_gtfs_rt_json is None:
+            print('ERROR - TripUpdate.from_gtfs_rt_json - StopTimeUpdate cant be None')
+            print(json_data.keys())
+            sys.exit()
+        
         for stop_time_update_json_data in stop_times_update_gtfs_rt_json:
             stop_time_update = StopTimeUpdate.from_gtfs_rt_json(stop_time_update_json_data)
             stopTimeUpdates.append(stop_time_update)
@@ -125,10 +204,22 @@ class Entity:
   
     @staticmethod
     def from_gtfs_rt_json(json_data):
+        id_json = read_safe_json_key(json_data, 'Id')
+        if id_json is None:
+            print('ERROR - Entity.from_gtfs_rt_json - Id cant be None')
+            print(json_data.keys())
+            sys.exit()
+            
+        tripUpdate_json = read_safe_json_key(json_data, 'TripUpdate')
+        if tripUpdate_json is None:
+            print('ERROR - Entity.from_gtfs_rt_json - TripUpdate cant be None')
+            print(json_data.keys())
+            sys.exit()
+        
         entity = Entity(
-            id=json_data['Id'],
-            isDeleted=json_data['IsDeleted'],
-            tripUpdate=TripUpdate.from_gtfs_rt_json(json_data['TripUpdate'])
+            id=id_json,
+            isDeleted=read_safe_json_key(json_data, 'IsDeleted'),
+            tripUpdate=TripUpdate.from_gtfs_rt_json(tripUpdate_json)
         )
     
         return entity
@@ -147,10 +238,21 @@ class GTFS_RT_Response:
   
     @staticmethod
     def from_gtfs_rt_json(json_data: dict):
-        header = Header.from_gtfs_rt_json(json_data['Header'])
+        header_json = read_safe_json_key(json_data, 'Header')
+        if header_json is None:
+            print('ERROR - GTFS_RT_Response.from_gtfs_rt_json - Header cant be None')
+            print(json_data.keys())
+            sys.exit()
+        header = Header.from_gtfs_rt_json(header_json)
     
         entities: List[Entity] = []
-        for entity_json_data in json_data['Entity']:
+        entities_json = read_safe_json_key(json_data, 'Entity')
+        if entities_json is None:
+            print('ERROR - GTFS_RT_Response.from_gtfs_rt_json - Entity cant be None')
+            print(json_data.keys())
+            sys.exit()
+        
+        for entity_json_data in entities_json:
             entity = Entity.from_gtfs_rt_json(entity_json_data)
             entities.append(entity)
     

--- a/tools/_shared/inc/models/gtfs_rt.py
+++ b/tools/_shared/inc/models/gtfs_rt.py
@@ -199,8 +199,8 @@ class TripUpdate:
 @dataclass
 class Entity:
     id: str
-    isDeleted: bool
     tripUpdate: TripUpdate
+    isDeleted: Optional[bool] = None
   
     @staticmethod
     def from_gtfs_rt_json(json_data):

--- a/tools/_shared/inc/models/gtfs_rt.py
+++ b/tools/_shared/inc/models/gtfs_rt.py
@@ -3,7 +3,22 @@ import os, sys
 import json
 
 from dataclasses import dataclass, asdict
-from typing import List, Optional
+from typing import List, Optional, Any
+
+def read_safe_json_key(json_data: dict[str, Any], key: str, default_value = None):
+    if not key[:1].isupper():
+        print('ERROR - this method should be use with UpperCase keys')
+        print(key)
+        sys.exit(1)
+    
+    camelCase_indicator = 'n/a - TRY_camelCase'
+    
+    value = json_data.get(key, camelCase_indicator)
+    if value == camelCase_indicator:
+        camelCase_key = key[:1].lower() + key[1:]
+        value = json_data.get(camelCase_key, default_value)
+        
+    return value
 
 @dataclass
 class Header:

--- a/tools/gtfs-rt-static-compare/CHANGELOG.md
+++ b/tools/gtfs-rt-static-compare/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG gtfs-rt-static-compare/
 
+08.Feb 2025
+- adds compare info, check prev 10 measurements
+- send emails in case of errors detected
+
 26.Feb 2025
 - updates authorization flow, API endpoints
 - adds CLI to fetch latest GTFS-RT

--- a/tools/gtfs-rt-static-compare/cli_aggregate_monthly_reports_json.py
+++ b/tools/gtfs-rt-static-compare/cli_aggregate_monthly_reports_json.py
@@ -182,6 +182,7 @@ def _fetch_map_reports(app_config: Any, report_filter_ym: str) -> dict[str, GTFS
 def _compute_and_save_monthly_report(app_config: Any, report_filter_ym: str, map_reports: dict[str, GTFS_RT_Static_Report_Metadata], map_compare: dict[str, GTFS_RT_Static_Report_Compare_Info]): 
     #                   YYYY-MM  >    DD    >   HH > GTFS_RT_Static_Report_Metadata
     map_reports_by_hr: dict[str, dict[str, dict[str, GTFS_RT_Static_Report_Metadata]]] = {}
+    map_compare_by_hr: dict[str, dict[str, dict[str, GTFS_RT_Static_Report_Compare_Info]]] = {}
     for report_key, report in map_reports.items():
         # 2025-07-01-00
         report_key_parts = report_key.split('-')
@@ -195,11 +196,15 @@ def _compute_and_save_monthly_report(app_config: Any, report_filter_ym: str, map
         
         if report_ym not in map_reports_by_hr:
             map_reports_by_hr[report_ym] = {}
+            map_compare_by_hr[report_ym] = {}
         
         if report_day_f not in map_reports_by_hr[report_ym]:
             map_reports_by_hr[report_ym][report_day_f] = {}
+            map_compare_by_hr[report_ym][report_day_f] = {}
             
         map_reports_by_hr[report_ym][report_day_f][report_hour_f] = report
+        if report_key in map_compare:
+            map_compare_by_hr[report_ym][report_day_f][report_hour_f] = map_compare[report_key]
     # loop reports
     
     report_now = datetime.now()
@@ -208,11 +213,13 @@ def _compute_and_save_monthly_report(app_config: Any, report_filter_ym: str, map
     
     for report_ym, report_data in map_reports_by_hr.items():
         report_year_f, _, report_month_f = report_ym.partition('-')
+        report_compare_data = map_compare_by_hr[report_ym]
         
         monthly_report = GTFS_RT_Static_Monthly_Report(
             last_update_dt=report_now_f,
             comments=report_comments,
             report_days=report_data,
+            compare_days=report_compare_data,
         )
         monthly_report_json = monthly_report.as_json()
         
@@ -245,6 +252,13 @@ def main():
     log_message(f'... done parsing {len(map_reports.keys())} reports')
     print()
     
+    map_compare: dict[str, GTFS_RT_Static_Report_Compare_Info] = {}
+    for report_key, _ in map_reports.items():
+        report_compare = _compute_compare(app_config, report_key, map_reports, map_compare)
+        map_compare[report_key] = report_compare
+    # loop compare
+    log_message('... finished compare files')
+    print()
     
     _compute_and_save_monthly_report(app_config, report_filter_ym, map_reports, map_compare)
     print()

--- a/tools/gtfs-rt-static-compare/cli_aggregate_monthly_reports_json.py
+++ b/tools/gtfs-rt-static-compare/cli_aggregate_monthly_reports_json.py
@@ -15,7 +15,7 @@ from compare_gtfs_rt_static.helpers.json_helpers import load_json_from_file, exp
 from compare_gtfs_rt_static.helpers.log_helpers import log_message
 
 from compare_gtfs_rt_static.models.gtfs_rt_static_report import GTFS_RT_Static_Report, GTFS_RT_Static_Monthly_Report, GTFS_RT_Static_Report_Compare_Info, GTFS_RT_Static_Report_Metadata
-from compare_gtfs_rt_static.gtfs_controller import gtfs_rt_static_report_file_regexp
+from compare_gtfs_rt_static.gtfs_controller import gtfs_rt_static_report_file_regexp, header_separator_s
 
 is_verbose_mode = False
 
@@ -252,18 +252,22 @@ def main():
     
     report_now = datetime.now()
     
-    default_filter_ym = report_now.strftime('%Y-%m')
     parser = argparse.ArgumentParser()
-    parser.add_argument('--month', '--month', default=default_filter_ym)
+    parser.add_argument('--month', '--month')
     args = parser.parse_args()
-    report_filter_ym = args.month
+    user_report_filter_ym = args.month
     
+    report_filter_ym = user_report_filter_ym
+    if report_filter_ym is None:
+        default_filter_ym = report_now.strftime('%Y-%m')
+        report_filter_ym = default_filter_ym
+    
+    print(header_separator_s)
     log_message(f'START cli_aggregate_monthly_reports_json with --month={report_filter_ym}')
-    print()
+    print(header_separator_s)
     
     map_reports = _fetch_map_reports(app_config, report_filter_ym)
     log_message(f'... done parsing {len(map_reports.keys())} reports')
-    print()
     
     map_compare: dict[str, GTFS_RT_Static_Report_Compare_Info] = {}
     for report_key, _ in map_reports.items():
@@ -271,12 +275,11 @@ def main():
         map_compare[report_key] = report_compare
     # loop compare
     log_message('... finished compare files')
-    print()
     
     _compute_and_save_monthly_report(app_config, report_filter_ym, map_reports, map_compare)
-    print()
     
     log_message('... DONE')
+    print(header_separator_s)
 
 if __name__ == "__main__":
     main()

--- a/tools/gtfs-rt-static-compare/cli_aggregate_monthly_reports_json.py
+++ b/tools/gtfs-rt-static-compare/cli_aggregate_monthly_reports_json.py
@@ -20,7 +20,12 @@ from compare_gtfs_rt_static.gtfs_controller import gtfs_rt_static_report_file_re
 is_verbose_mode = False
 
 def _compute_compare(app_config: Any, report_key: str, map_hr_report: dict[str, GTFS_RT_Static_Report_Metadata], map_compare: dict[str, GTFS_RT_Static_Report_Compare_Info]):
-    compare_info = GTFS_RT_Static_Report_Compare_Info('h', {})
+    compare_info = GTFS_RT_Static_Report_Compare_Info(
+        compare_type='h',
+        mean_value=-1,
+        drop_line=-1,
+        map_days={},
+    )
     
     report_ymd_f = report_key[0:10]
     report_hr_f = report_key[-2:]
@@ -82,6 +87,9 @@ def _compute_compare(app_config: Any, report_key: str, map_hr_report: dict[str, 
         
         report = map_hr_report[report_key]
         report_total_rows_no = report.total_rows_no
+        
+        compare_info.drop_line = drop_line
+        compare_info.mean_value = measure_mean
         
         if report_total_rows_no < drop_line:
             compare_info.compare_type = 'w_p'

--- a/tools/gtfs-rt-static-compare/cli_aggregate_monthly_reports_json.py
+++ b/tools/gtfs-rt-static-compare/cli_aggregate_monthly_reports_json.py
@@ -249,6 +249,11 @@ def _analyse_last_report(map_reports: dict[str, GTFS_RT_Static_Report_Metadata],
     report_now = datetime.now()
     report_now_f = report_now.strftime('%Y-%m-%d-%H')
     
+    # ignore outside of normal hours
+    report_hr = int(report_now_f[-2:])
+    if (report_hr < 6) or (report_hr > 18):
+        return
+    
     error_message = None
     
     if report_now_f not in map_reports:

--- a/tools/gtfs-rt-static-compare/cli_aggregate_monthly_reports_json.py
+++ b/tools/gtfs-rt-static-compare/cli_aggregate_monthly_reports_json.py
@@ -245,6 +245,35 @@ def _compute_and_save_monthly_report(app_config: Any, report_filter_ym: str, map
         log_message(f'... saved {report_ym} to {monthly_report_path.name}')
     # loop months
 
+def _analyse_last_report(map_reports: dict[str, GTFS_RT_Static_Report_Metadata], map_compare: dict[str, GTFS_RT_Static_Report_Compare_Info]):
+    report_now = datetime.now()
+    report_now_f = report_now.strftime('%Y-%m-%d-%H')
+    
+    error_message = None
+    
+    if report_now_f not in map_reports:
+        error_message = f'ERROR - cant find {report_now_f} report, is GTFS-RT endpoint working?'
+    if report_now_f not in map_compare:
+        error_message = f'ERROR - cant find {report_now_f} compare report'
+        
+    if error_message is not None:
+        raise Exception(error_message)
+    
+    report = map_reports[report_now_f]
+    report_compare = map_compare[report_now_f]
+    
+    if report_compare.compare_type == 'w_p':
+        error_message = f'ERROR - DROP deteced in number of GTFS-RT items'
+        
+    if report.tripNOK_NOJP_no > 0:
+        error_message = f'ERROR - GTFS-RT / -static is out of sync, discovered {report.tripNOK_NOJP_no} items not in GTFS-static'
+        
+    if abs(report.gtfs_rt_age) > 60:
+        error_message = f'ERROR - GTFS-RT age is greater than 60seconds: {report.gtfs_rt_age}'
+                
+    if error_message is not None:
+        raise Exception(error_message)
+
 def main():
     app_path = Path(os.path.realpath(__file__)).parent
     config_path = Path(f'{app_path}/config/config.yml')
@@ -280,6 +309,9 @@ def main():
     
     log_message('... DONE')
     print(header_separator_s)
+    
+    if user_report_filter_ym is None:
+        _analyse_last_report(map_reports, map_compare)
 
 if __name__ == "__main__":
     main()

--- a/tools/gtfs-rt-static-compare/cli_aggregate_monthly_reports_json.py
+++ b/tools/gtfs-rt-static-compare/cli_aggregate_monthly_reports_json.py
@@ -254,18 +254,25 @@ def _analyse_last_report(map_reports: dict[str, GTFS_RT_Static_Report_Metadata],
     if (report_hr < 6) or (report_hr > 18):
         return
     
+    # compare report is not available, dont throw an error
+    if report_now_f not in map_compare:
+        return
+    
+    report_compare = map_compare[report_now_f]
+    
+    # ignore holidays
+    if report_compare.compare_type == 'h':
+        return
+    
     error_message = None
     
     if report_now_f not in map_reports:
         error_message = f'ERROR - cant find {report_now_f} report, is GTFS-RT endpoint working?'
-    if report_now_f not in map_compare:
-        error_message = f'ERROR - cant find {report_now_f} compare report'
         
     if error_message is not None:
         raise Exception(error_message)
     
     report = map_reports[report_now_f]
-    report_compare = map_compare[report_now_f]
     
     if report_compare.compare_type == 'w_p':
         error_message = f'ERROR - DROP deteced in number of GTFS-RT items'

--- a/tools/gtfs-rt-static-compare/cli_aggregate_monthly_reports_json.py
+++ b/tools/gtfs-rt-static-compare/cli_aggregate_monthly_reports_json.py
@@ -179,6 +179,11 @@ def _fetch_map_reports(app_config: Any, report_filter_ym: str) -> dict[str, GTFS
         report_month_f = file_matches[2]
         report_day_f = file_matches[3]
         report_hour_f = file_matches[4]
+        report_min_f = file_matches[5]
+        
+        # Discard reports that are not run on cronjob basis (every hour)
+        if report_min_f != '00':
+            continue
         
         report_key = f'{report_year_f}-{report_month_f}-{report_day_f}-{report_hour_f}'
         

--- a/tools/gtfs-rt-static-compare/cli_aggregate_monthly_reports_json.py
+++ b/tools/gtfs-rt-static-compare/cli_aggregate_monthly_reports_json.py
@@ -2,84 +2,254 @@ import os, sys
 
 import re
 import argparse
-from datetime import datetime
+from datetime import datetime, date, timedelta
 
 from pathlib import Path
 
-from typing import List, Dict
+from typing import Any, List, Optional
+
+from statistics import mean, median
 
 from compare_gtfs_rt_static.helpers.config_helpers import load_yaml_config
 from compare_gtfs_rt_static.helpers.json_helpers import load_json_from_file, export_json_to_file
 from compare_gtfs_rt_static.helpers.log_helpers import log_message
 
-from compare_gtfs_rt_static.models.gtfs_rt_static_report import GTFS_RT_Static_Report, GTFS_RT_Static_Monthly_Report
+from compare_gtfs_rt_static.models.gtfs_rt_static_report import GTFS_RT_Static_Report, GTFS_RT_Static_Monthly_Report, GTFS_RT_Static_Report_Compare_Info, GTFS_RT_Static_Report_Metadata
+from compare_gtfs_rt_static.gtfs_controller import gtfs_rt_static_report_file_regexp
 
-def main():
-    app_path = Path(os.path.realpath(__file__)).parent
-    config_path = f'{app_path}/config/config.yml'
+is_verbose_mode = False
+
+def _compute_compare(app_config: Any, report_key: str, map_hr_report: dict[str, GTFS_RT_Static_Report_Metadata], map_compare: dict[str, GTFS_RT_Static_Report_Compare_Info]):
+    compare_info = GTFS_RT_Static_Report_Compare_Info('h', {})
     
-    app_config = load_yaml_config(config_path, app_path)
-    report_template_path: str = app_config['resource_paths']['gtfs_rt_static_report']
-    report_root_path = Path(report_template_path.split('[YEAR]/[MONTH]/[DAY]')[0])
+    report_ymd_f = report_key[0:10]
+    report_hr_f = report_key[-2:]
     
-    report_now = datetime.now()
-    report_ym = report_now.strftime('%Y-%m')
+    if report_ymd_f in app_config['map_holidays']:
+        return compare_info
     
-    parser = argparse.ArgumentParser()
-    parser.add_argument('--month', '--month', default=report_ym)
-    args = parser.parse_args()
+    report_ymd = date.fromisoformat(report_ymd_f)
     
-    report_ym = args.month
+    # Monday == 0 ... Sunday == 6
+    report_weekday = report_ymd.weekday()
+    report_hr = int(report_hr_f)
+    # GTFS day starts at 4:00, everything earlier belongs to the previous day
+    if report_hr < 4:
+        report_weekday -= 1
+        if report_weekday == -1:
+            report_weekday = 6
+            
+    if report_weekday > 4:
+        return compare_info
     
-    log_message(f'START aggregate reports for {report_ym}')
+    compare_info.compare_type = 'w'
     
-    report_month_parts = report_ym.split('-')
-    report_year = report_month_parts[0]
-    report_month = report_month_parts[1]
-    
-    report_month_part = Path(f'{report_root_path}/{report_year}/{report_month}')
-    report_file_paths: List[Path] = []
-    for gtfs_rt_report_path in report_month_part.rglob('*.json'):
-        report_file_paths.append(gtfs_rt_report_path)
-    report_file_paths.sort()
-    
-    map_report_days: Dict[str, Dict[str, GTFS_RT_Static_Report]] = {}
-    for gtfs_rt_report_path in report_file_paths:
-        gtfs_rt_report_json = load_json_from_file(gtfs_rt_report_path)
-        gtfs_rt_report = GTFS_RT_Static_Report.from_json(gtfs_rt_report_json)
+    prev_report_day = date.fromisoformat(report_ymd_f)
+    days_back_idx = 0
+    days_back_max = 100
+    days_compare_max = 10
+    while days_back_idx < days_back_max:
+        prev_report_day -= timedelta(days=1)
         
-        file_matches = re.match(r"gtfs_rt_static_report-([0-9]{4})-([0-9]{2})-([0-9]{2})-([0-9]{2})([0-9]{2})", gtfs_rt_report_path.name)
+        prev_report_key = f'{prev_report_day}-{report_hr_f}'
+        if prev_report_key in map_hr_report:
+            prev_compare = map_compare.get(prev_report_key, None)
+        
+            is_prev_working_day = False
+            if prev_compare is not None:
+                if prev_compare.compare_type == 'w':
+                    is_prev_working_day = True
+            # check if prev compare is working day
+            
+            if is_prev_working_day:
+                prev_total_rows_no = map_hr_report[prev_report_key].total_rows_no
+                compare_info.map_days[f'{prev_report_day}'] = prev_total_rows_no
+            # if
+        # check if we have report
+        
+        if len(compare_info.map_days.keys()) >= days_compare_max:
+            break
+            
+        days_back_idx += 1
+    # while days back
+    
+    is_relevant = (6 <= report_hr <= 20)
+    has_prev_data = len(compare_info.map_days.keys()) == days_compare_max
+    if has_prev_data and is_relevant:
+        prev_values = compare_info.map_days.values()
+        measure_mean = median(prev_values)
+        drop_line = measure_mean * (1 - 0.1)
+        
+        report = map_hr_report[report_key]
+        report_total_rows_no = report.total_rows_no
+        
+        if report_total_rows_no < drop_line:
+            compare_info.compare_type = 'w_p'
+            
+            if is_verbose_mode:
+                print(f'possible issue:')
+                print(f'  {report_ymd_f} {report_hr_f}:00')
+                print(f'  rows      : {report_total_rows_no}')
+                print(f'  drop_line : {drop_line}')
+                print()
+                
+                for prev_day, prev_day_no in  compare_info.map_days.items():
+                    print(f'    {prev_day}: {prev_day_no}')
+                    
+                print()
+            # verbose
+        # if drop line was reached
+            
+    # check if we should analyse
+    
+    return compare_info
+
+def _fetch_map_reports(app_config: Any, report_filter_ym: str) -> dict[str, GTFS_RT_Static_Report_Metadata]:
+    report_template_path: str = app_config['resource_paths']['gtfs_rt_static_report']
+    report_base_path = Path(report_template_path.split('[YEAR]/[MONTH]/[DAY]')[0])
+    
+    report_filter_months: Optional[List[str]] = None
+    if report_filter_ym != 'ALL':
+        report_filter_ym_parts = report_filter_ym.split('-')
+        dir_y_s = report_filter_ym_parts[0]
+        dir_m_s = report_filter_ym_parts[1]
+        dir_ym = f'{dir_y_s}-{dir_m_s}'
+        
+        prev_dir_y = int(dir_y_s)
+        prev_dir_m = int(dir_m_s) - 1
+        if prev_dir_m == 0:
+            prev_dir_y -= 1
+            prev_dir_m = 12
+        prev_dir_y_s = f'{prev_dir_y}'.zfill(2)
+        prev_dir_m_s = f'{prev_dir_m}'.zfill(2)
+        prev_dir_ym = f'{prev_dir_y_s}-{prev_dir_m_s}'
+        
+        report_filter_months = [prev_dir_ym, dir_ym]
+    # end build yyyy-mm filter
+    
+    report_subdirs: List[Path] = []
+    for report_subdir in report_base_path.glob('*/*'):
+        if not report_subdir.is_dir():
+            continue
+        
+        if report_filter_months is not None:
+            report_subdir_paths = f'{report_subdir}'.split('/')
+            report_subdir_ym = f'{report_subdir_paths[-2]}-{report_subdir_paths[-1]}'
+            if report_subdir_ym not in report_filter_months:
+                continue
+        # check if filter YYYY-MM is active and matches subdir
+        
+        report_subdirs.append(report_subdir)
+    # loop subdirs
+    report_subdirs.sort()
+    
+    report_file_paths: List[Path] = []
+    for report_subdir in report_subdirs:
+        report_subdir_paths = f'{report_subdir}'.split('/')
+        report_year_f = report_subdir_paths[-2]
+        report_month_f = report_subdir_paths[-1]
+        report_month_path = Path(f'{report_base_path}/{report_year_f}/{report_month_f}')
+        for gtfs_rt_report_path in report_month_path.rglob('*.json'):
+            report_file_paths.append(gtfs_rt_report_path)
+        # loop subdir JSON files
+    # loop subdirs
+    report_file_paths.sort()
+    log_message(f'... found {len(report_file_paths)} files')
+    
+    map_reports: dict[str, GTFS_RT_Static_Report_Metadata] = {}
+    for report_path in report_file_paths:
+        file_matches = re.match(gtfs_rt_static_report_file_regexp, report_path.name)
         if file_matches is None:
             print('ERROR - unknown file pattern')
-            print(gtfs_rt_report_path)
+            print(report_path)
             sys.exit(1)
-            
-        report_day = file_matches[3]
-        report_hhmm = file_matches[4] + file_matches[5]
         
-        if report_day not in map_report_days:
-            map_report_days[report_day] = {}
-            
-        map_report_days[report_day][report_hhmm] = gtfs_rt_report.metadata.as_json()
-    # report_file_paths
+        report_json = load_json_from_file(report_path)
+        report = GTFS_RT_Static_Report.from_json(report_json)
+        
+        report_year_f = file_matches[1]
+        report_month_f = file_matches[2]
+        report_day_f = file_matches[3]
+        report_hour_f = file_matches[4]
+        
+        report_key = f'{report_year_f}-{report_month_f}-{report_day_f}-{report_hour_f}'
+        
+        map_reports[report_key] = report.metadata
+    # loop report_file_paths
     
+    return map_reports
+
+def _compute_and_save_monthly_report(app_config: Any, report_filter_ym: str, map_reports: dict[str, GTFS_RT_Static_Report_Metadata], map_compare: dict[str, GTFS_RT_Static_Report_Compare_Info]): 
+    #                   YYYY-MM  >    DD    >   HH > GTFS_RT_Static_Report_Metadata
+    map_reports_by_hr: dict[str, dict[str, dict[str, GTFS_RT_Static_Report_Metadata]]] = {}
+    for report_key, report in map_reports.items():
+        # 2025-07-01-00
+        report_key_parts = report_key.split('-')
+        report_ym = '-'.join(report_key_parts[0:2])
+        report_day_f = report_key_parts[2]
+        report_hour_f = f'{report_key_parts[3]}00'
+        
+        if report_filter_ym != 'ALL':
+            if report_ym != report_filter_ym:
+                continue
+        
+        if report_ym not in map_reports_by_hr:
+            map_reports_by_hr[report_ym] = {}
+        
+        if report_day_f not in map_reports_by_hr[report_ym]:
+            map_reports_by_hr[report_ym][report_day_f] = {}
+            
+        map_reports_by_hr[report_ym][report_day_f][report_hour_f] = report
+    # loop reports
+    
+    report_now = datetime.now()
     report_now_f = report_now.strftime('%Y-%m-%d %H:%M:%S')
     report_comments = f'generated {report_now_f} with {Path(__file__).name}'
     
-    gtfs_rt_static_monthly_report = GTFS_RT_Static_Monthly_Report(
-        last_update_dt=report_now_f,
-        comments=report_comments,
-        report_days=map_report_days
-    )
+    for report_ym, report_data in map_reports_by_hr.items():
+        report_year_f, _, report_month_f = report_ym.partition('-')
+        
+        monthly_report = GTFS_RT_Static_Monthly_Report(
+            last_update_dt=report_now_f,
+            comments=report_comments,
+            report_days=report_data,
+        )
+        monthly_report_json = monthly_report.as_json()
+        
+        monthly_report_path_s: str = app_config['resource_paths']['gtfs_rt_static_mo_json']
+        monthly_report_path_s = monthly_report_path_s.replace('[YEAR]', report_year_f)
+        monthly_report_path_s = monthly_report_path_s.replace('[MONTH]', report_month_f)
+        monthly_report_path = Path(monthly_report_path_s)
+        
+        export_json_to_file(monthly_report_json, json_path=monthly_report_path, pretty_print=True)
+        log_message(f'... saved {report_ym} to {monthly_report_path.name}')
+    # loop months
+
+def main():
+    app_path = Path(os.path.realpath(__file__)).parent
+    config_path = Path(f'{app_path}/config/config.yml')
+    app_config = load_yaml_config(config_path, app_path)
     
-    report_path: str = app_config['resource_paths']['gtfs_rt_static_mo_json']
-    report_path = report_path.replace('[YEAR]', report_year)
-    report_path = report_path.replace('[MONTH]', report_month)
+    report_now = datetime.now()
     
-    export_json_to_file(gtfs_rt_static_monthly_report.as_json(), json_path=report_path, pretty_print=True)
-    log_message(f'... saved {len(report_file_paths)} reports to {report_path}')
+    default_filter_ym = report_now.strftime('%Y-%m')
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--month', '--month', default=default_filter_ym)
+    args = parser.parse_args()
+    report_filter_ym = args.month
     
-    log_message(f'... DONE')
+    log_message(f'START cli_aggregate_monthly_reports_json with --month={report_filter_ym}')
+    print()
+    
+    map_reports = _fetch_map_reports(app_config, report_filter_ym)
+    log_message(f'... done parsing {len(map_reports.keys())} reports')
+    print()
+    
+    
+    _compute_and_save_monthly_report(app_config, report_filter_ym, map_reports, map_compare)
+    print()
+    
+    log_message('... DONE')
 
 if __name__ == "__main__":
     main()

--- a/tools/gtfs-rt-static-compare/cli_compare_latest.sh
+++ b/tools/gtfs-rt-static-compare/cli_compare_latest.sh
@@ -1,7 +1,0 @@
-DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
-
-source $DIR/../scripts/common.sh
-source $PYTHON_VENV_PATH/bin/activate
-
-python3 $DIR/cli_compare_latest.py
-python3 $DIR/cli_aggregate_monthly_reports_json.py

--- a/tools/gtfs-rt-static-compare/compare_gtfs_rt_static/gtfs_controller.py
+++ b/tools/gtfs-rt-static-compare/compare_gtfs_rt_static/gtfs_controller.py
@@ -12,7 +12,7 @@ import shutil
 from .helpers.config_helpers import load_yaml_config
 from .helpers.gtfs_helpers import compute_gtfs_db_filename
 from .helpers.json_helpers import load_json_from_file, export_json_to_file
-from .helpers.log_helpers import log_message
+from .helpers.log_helpers import format_path, log_message
 
 from .models.gtfs_static_db_catalog import GTFS_Static_Catalog_Report, GTFS_Static_Catalog_Item
 from .models.gtfs_rt import GTFS_RT_Response
@@ -49,6 +49,8 @@ class GTFS_Controller:
         
     # PRIVATE
     def _compare_compare_latest_gtfs_rt_static(self):
+        app_path: str = self.app_config['resource_paths']['app_path']
+        
         header_separator_s = '-' * 60
         
         print(header_separator_s)
@@ -65,7 +67,7 @@ class GTFS_Controller:
         
         gtfs_rt_response = fetch_latest(self.app_config, gtfs_rt_snapshot_path)
         log_message(f'... DONE fetch')
-        print(f'saved to {gtfs_rt_snapshot_path}')
+        print(f'saved to {format_path(f'{gtfs_rt_snapshot_path}', app_path)}')
         print(header_separator_s)
         
         gtfs_rt_dt = datetime.fromtimestamp(gtfs_rt_response.header.timestamp)
@@ -117,7 +119,7 @@ class GTFS_Controller:
         print(f'Report URL          : {report_url}')
         print(header_separator_s)
         
-        print(f'... saved to {report_path}')
+        print(f'... saved to {format_path(f'{report_path}', app_path)}')
         print(header_separator_s)
         
         print(f'... cleaning up, gzip resource')
@@ -270,8 +272,7 @@ class GTFS_Controller:
         log_message(f'... DONE fetch')
         
         app_path = self.app_config['resource_paths']['app_path']
-        rel_path = f'{gtfs_rt_snapshot_path}'.replace(app_path, '.')
         
         print()
-        print(f'saved to {rel_path}')
+        print(f'... saved to {format_path(f'{gtfs_rt_snapshot_path}', app_path)}')
         print(header_separator_s)

--- a/tools/gtfs-rt-static-compare/compare_gtfs_rt_static/gtfs_controller.py
+++ b/tools/gtfs-rt-static-compare/compare_gtfs_rt_static/gtfs_controller.py
@@ -22,6 +22,7 @@ from .gtfs_db import GTFS_DB
 
 from .fetch import fetch_latest, compute_resource_snapshot_path
 
+gtfs_rt_static_report_file_regexp = r"gtfs_rt_static_report-([0-9]{4})-([0-9]{2})-([0-9]{2})-([0-9]{2})([0-9]{2})"
 class GTFS_Controller:
     def __init__(self, app_path: Path):
         config_path = Path(f'{app_path}/config/config.yml')

--- a/tools/gtfs-rt-static-compare/compare_gtfs_rt_static/gtfs_controller.py
+++ b/tools/gtfs-rt-static-compare/compare_gtfs_rt_static/gtfs_controller.py
@@ -276,5 +276,6 @@ class GTFS_Controller:
         app_path = self.app_config['resource_paths']['app_path']
         
         print()
-        print(f'... saved to {format_path(f'{gtfs_rt_snapshot_path}', app_path)}')
+        gtfs_rt_snapshot_path_s = format_path(f'{gtfs_rt_snapshot_path}', app_path)
+        print(f'... saved to {gtfs_rt_snapshot_path_s}')
         print(header_separator_s)

--- a/tools/gtfs-rt-static-compare/compare_gtfs_rt_static/gtfs_controller.py
+++ b/tools/gtfs-rt-static-compare/compare_gtfs_rt_static/gtfs_controller.py
@@ -119,14 +119,12 @@ class GTFS_Controller:
         print(f'Report URL          : {report_url}')
         print(header_separator_s)
         
-        report_path_s = format_path(f'{report_path}', app_path)
-        print(f'... saved to {report_path_s}')
-        print(header_separator_s)
-        
-        print(f'... cleaning up, gzip resource')
+        log_message('... cleaning up, archive(gzip) resource')
         self._cleanup_resource(gtfs_rt_snapshot_path)
         
         log_message('... DONE')
+        print(header_separator_s)
+        print()
         
     def _load_gtfs_db(self, gtfs_catalog_item: GTFS_Static_Catalog_Item):
         gtfs_dbs_basepath = Path(self.app_config['resource_paths']['gtfs_db']).parent

--- a/tools/gtfs-rt-static-compare/compare_gtfs_rt_static/gtfs_controller.py
+++ b/tools/gtfs-rt-static-compare/compare_gtfs_rt_static/gtfs_controller.py
@@ -120,7 +120,8 @@ class GTFS_Controller:
         print(f'Report URL          : {report_url}')
         print(header_separator_s)
         
-        print(f'... saved to {format_path(f'{report_path}', app_path)}')
+        report_path_s = format_path(f'{report_path}', app_path)
+        print(f'... saved to {report_path_s}')
         print(header_separator_s)
         
         print(f'... cleaning up, gzip resource')

--- a/tools/gtfs-rt-static-compare/compare_gtfs_rt_static/gtfs_controller.py
+++ b/tools/gtfs-rt-static-compare/compare_gtfs_rt_static/gtfs_controller.py
@@ -76,6 +76,10 @@ class GTFS_Controller:
         log_message(f'... LOAD DB GTFS-DAY: {gtfs_catalog_item.gtfs_day} - {gtfs_catalog_item.db_relative_path}')
             
         gtfs_db = self._load_gtfs_db(gtfs_catalog_item)
+        if gtfs_db is None:
+            print('WHOOPS - no DB')
+            print(gtfs_catalog_item)
+            sys.exit(1)
         
         log_message(f'... DONE LOAD DB')
         print(header_separator_s)

--- a/tools/gtfs-rt-static-compare/compare_gtfs_rt_static/gtfs_controller.py
+++ b/tools/gtfs-rt-static-compare/compare_gtfs_rt_static/gtfs_controller.py
@@ -2,8 +2,6 @@ import os, sys
 
 from pathlib import Path
 
-import re
-
 from typing import Union
 
 from datetime import datetime

--- a/tools/gtfs-rt-static-compare/compare_gtfs_rt_static/gtfs_controller.py
+++ b/tools/gtfs-rt-static-compare/compare_gtfs_rt_static/gtfs_controller.py
@@ -24,7 +24,7 @@ from .fetch import fetch_latest, compute_resource_snapshot_path
 
 class GTFS_Controller:
     def __init__(self, app_path: Path):
-        config_path = f'{app_path}/config/config.yml'
+        config_path = Path(f'{app_path}/config/config.yml')
         self.app_config = load_yaml_config(config_path, app_path=app_path)
         
         gtfs_dbs_report_path = self.app_config['resource_paths']['gtfs_dbs_json_path']

--- a/tools/gtfs-rt-static-compare/compare_gtfs_rt_static/gtfs_controller.py
+++ b/tools/gtfs-rt-static-compare/compare_gtfs_rt_static/gtfs_controller.py
@@ -23,6 +23,7 @@ from .gtfs_db import GTFS_DB
 from .fetch import fetch_latest, compute_resource_snapshot_path
 
 gtfs_rt_static_report_file_regexp = r"gtfs_rt_static_report-([0-9]{4})-([0-9]{2})-([0-9]{2})-([0-9]{2})([0-9]{2})"
+header_separator_s = '-' * 60
 class GTFS_Controller:
     def __init__(self, app_path: Path):
         config_path = Path(f'{app_path}/config/config.yml')
@@ -50,8 +51,6 @@ class GTFS_Controller:
     # PRIVATE
     def _compare_compare_latest_gtfs_rt_static(self):
         app_path: str = self.app_config['resource_paths']['app_path']
-        
-        header_separator_s = '-' * 60
         
         print(header_separator_s)
         log_message(f'START COMPARE GTFS -RT GTFS STATIC')

--- a/tools/gtfs-rt-static-compare/compare_gtfs_rt_static/gtfs_controller.py
+++ b/tools/gtfs-rt-static-compare/compare_gtfs_rt_static/gtfs_controller.py
@@ -67,7 +67,8 @@ class GTFS_Controller:
         
         gtfs_rt_response = fetch_latest(self.app_config, gtfs_rt_snapshot_path)
         log_message(f'... DONE fetch')
-        print(f'saved to {format_path(f'{gtfs_rt_snapshot_path}', app_path)}')
+        gtfs_rt_snapshot_path_s = format_path(f'{gtfs_rt_snapshot_path}', app_path)
+        print(f'saved to {gtfs_rt_snapshot_path_s}')
         print(header_separator_s)
         
         gtfs_rt_dt = datetime.fromtimestamp(gtfs_rt_response.header.timestamp)

--- a/tools/gtfs-rt-static-compare/compare_gtfs_rt_static/models/gtfs_rt_static_report.py
+++ b/tools/gtfs-rt-static-compare/compare_gtfs_rt_static/models/gtfs_rt_static_report.py
@@ -72,6 +72,7 @@ class GTFS_RT_Static_Report:
     @staticmethod
     def from_json(report_json: dict[str, Any]):
         report = GTFS_RT_Static_Report(**report_json)
+        
         report.metadata = GTFS_RT_Static_Report_Metadata.from_json(report_json['metadata'])
         
         entity_group_keys = ['tripOK_routeNOK', 'tripNOK_routeOK', 'tripNOK_routeNOK']

--- a/tools/gtfs-rt-static-compare/compare_gtfs_rt_static/models/gtfs_rt_static_report.py
+++ b/tools/gtfs-rt-static-compare/compare_gtfs_rt_static/models/gtfs_rt_static_report.py
@@ -1,8 +1,8 @@
 import os, sys
 
 from dataclasses import dataclass, asdict
-from typing import List, Dict
 from datetime import datetime
+from typing import Any
 
 from .gtfs_rt import Entity
 @dataclass
@@ -61,9 +61,9 @@ class GTFS_RT_Static_Report_Metadata:
 class GTFS_RT_Static_Report:
     metadata: GTFS_RT_Static_Report_Metadata
     
-    tripOK_routeNOK: List[str]
-    tripNOK_routeOK: List[str]
-    tripNOK_routeNOK: List[str]
+    tripOK_routeNOK: list[str]
+    tripNOK_routeOK: list[str]
+    tripNOK_routeNOK: list[str]
     
     @staticmethod
     def init_with_metadata(metdata: GTFS_RT_Static_Report_Metadata):
@@ -71,7 +71,7 @@ class GTFS_RT_Static_Report:
         return report
     
     @staticmethod
-    def from_json(report_json):
+    def from_json(report_json: dict[str, Any]):
         report = GTFS_RT_Static_Report(**report_json)
         report.metadata = GTFS_RT_Static_Report_Metadata.from_json(report_json['metadata'])
         
@@ -96,7 +96,7 @@ class GTFS_RT_Static_Report:
 class GTFS_RT_Static_Monthly_Report:
     comments: str
     last_update_dt: str
-    report_days: Dict[str, Dict[str, GTFS_RT_Static_Report_Metadata]]
+    report_days: dict[str, dict[str, GTFS_RT_Static_Report_Metadata]]
     
     def as_json(self):
         data_json = asdict(self)

--- a/tools/gtfs-rt-static-compare/compare_gtfs_rt_static/models/gtfs_rt_static_report.py
+++ b/tools/gtfs-rt-static-compare/compare_gtfs_rt_static/models/gtfs_rt_static_report.py
@@ -4,7 +4,6 @@ from dataclasses import dataclass, asdict
 from datetime import datetime
 from typing import Any
 
-from .gtfs_rt import Entity
 @dataclass
 class GTFS_RT_Static_Report_Compare_Info:
     compare_type: str # h - holiday; w - workday; w_p - workday with problems;

--- a/tools/gtfs-rt-static-compare/compare_gtfs_rt_static/models/gtfs_rt_static_report.py
+++ b/tools/gtfs-rt-static-compare/compare_gtfs_rt_static/models/gtfs_rt_static_report.py
@@ -101,4 +101,10 @@ class GTFS_RT_Static_Monthly_Report:
     def as_json(self):
         data_json = asdict(self)
         
+        for report_day, day_data in self.report_days.items():
+            for report_hr, hr_data_o in day_data.items():
+                hr_data: GTFS_RT_Static_Report_Metadata = hr_data_o
+                data_json['report_days'][report_day][report_hr] = hr_data.as_json()
+        # for
+        
         return data_json

--- a/tools/gtfs-rt-static-compare/compare_gtfs_rt_static/models/gtfs_rt_static_report.py
+++ b/tools/gtfs-rt-static-compare/compare_gtfs_rt_static/models/gtfs_rt_static_report.py
@@ -97,6 +97,7 @@ class GTFS_RT_Static_Monthly_Report:
     comments: str
     last_update_dt: str
     report_days: dict[str, dict[str, GTFS_RT_Static_Report_Metadata]]
+    compare_days: dict[str, dict[str, GTFS_RT_Static_Report_Compare_Info]]
     
     def as_json(self):
         data_json = asdict(self)

--- a/tools/gtfs-rt-static-compare/compare_gtfs_rt_static/models/gtfs_rt_static_report.py
+++ b/tools/gtfs-rt-static-compare/compare_gtfs_rt_static/models/gtfs_rt_static_report.py
@@ -44,8 +44,8 @@ class GTFS_RT_Static_Report_Metadata:
     @staticmethod
     def from_json(data_json):
         metadata = GTFS_RT_Static_Report_Metadata(**data_json)
-        metadata.report_dt = datetime.strptime(metadata.report_dt, '%Y-%m-%d %H:%M:%S')
-        metadata.gtfs_rt_dt = datetime.strptime(metadata.gtfs_rt_dt, '%Y-%m-%d %H:%M:%S')
+        metadata.report_dt = datetime.strptime(data_json['report_dt'], '%Y-%m-%d %H:%M:%S')
+        metadata.gtfs_rt_dt = datetime.strptime(data_json['gtfs_rt_dt'], '%Y-%m-%d %H:%M:%S')
         
         return metadata
     

--- a/tools/gtfs-rt-static-compare/compare_gtfs_rt_static/models/gtfs_rt_static_report.py
+++ b/tools/gtfs-rt-static-compare/compare_gtfs_rt_static/models/gtfs_rt_static_report.py
@@ -8,8 +8,8 @@ from typing import Any
 class GTFS_RT_Static_Report_Compare_Info:
     compare_type: str # h - holiday; w - workday; w_p - workday with problems;
     map_days: dict[str, int]
-    
-    # add drop_line, 
+    mean_value: float
+    drop_line: float
     
     @staticmethod
     def from_json(data_json):

--- a/tools/gtfs-rt-static-compare/compare_gtfs_rt_static/models/gtfs_rt_static_report.py
+++ b/tools/gtfs-rt-static-compare/compare_gtfs_rt_static/models/gtfs_rt_static_report.py
@@ -5,6 +5,17 @@ from typing import List, Dict
 from datetime import datetime
 
 from .gtfs_rt import Entity
+@dataclass
+class GTFS_RT_Static_Report_Compare_Info:
+    compare_type: str # h - holiday; w - workday; w_p - workday with problems;
+    map_days: dict[str, int]
+    
+    # add drop_line, 
+    
+    @staticmethod
+    def from_json(data_json):
+        compare_info = GTFS_RT_Static_Report_Compare_Info(**data_json)
+        return compare_info
 
 @dataclass
 class GTFS_RT_Static_Report_Metadata:

--- a/tools/gtfs-rt-static-compare/config/config.yml
+++ b/tools/gtfs-rt-static-compare/config/config.yml
@@ -10,3 +10,50 @@ resource_paths:
 
 opentransportdata:
   gtfs_rt_url: https://api.opentransportdata.swiss/la/gtfs-rt?format=JSON
+
+# TODO - needs to be generated
+map_holidays:
+  # 2024
+  "2024-01-01": New Years
+  "2024-01-02": Berchtold's Day
+  "2024-03-28": Maundy Thursday
+  "2024-04-01": Easter Monday
+  "2024-05-09": Ascension Day
+  "2024-05-20": Whit Monday
+  "2024-08-01": National Day
+  "2024-12-25": Christmas Day
+  "2024-12-26": Saint Stephen's Day
+  
+  # 2025
+  "2025-01-01": New Years
+  "2025-01-02": Berchtold's Day
+  "2025-04-17": Maundy Thursday
+  "2025-04-21": Easter Monday
+  "2025-05-29": Ascension Day
+  "2025-06-09": Whit Monday
+  "2025-08-01": National Day
+  "2025-12-25": Christmas Day
+  "2025-12-26": Saint Stephen's Day
+  
+  # 2026
+  "2026-01-01": New Years
+  "2026-01-02": Berchtold's Day
+  "2026-04-02": Maundy Thursday
+  "2026-04-06": Easter Monday
+  "2026-05-14": Ascension Day
+  "2026-05-25": Whit Monday
+  "2026-08-01": National Day
+  "2026-12-25": Christmas Day
+  "2026-12-26": Saint Stephen's Day
+
+  # 2027
+  "2027-01-01": New Years
+  "2027-01-02": Berchtold's Day
+  "2027-03-25": Maundy Thursday
+  "2027-03-29": Easter Monday
+  "2027-05-06": Ascension Day
+  "2027-05-17": Whit Monday
+  "2027-08-01": National Day
+  "2027-12-25": Christmas Day
+  "2027-12-26": Saint Stephen's Day
+

--- a/tools/scripts/.env
+++ b/tools/scripts/.env
@@ -1,0 +1,4 @@
+# default FROM email address
+DEFAULT_MAIL_FROM=from@mydomain.com
+
+GTFS_RT_STATIC_COMPARE_MAIL_TO=to@mydomain.com

--- a/tools/scripts/cli_otd_compare_gtfs_rt_static.sh
+++ b/tools/scripts/cli_otd_compare_gtfs_rt_static.sh
@@ -1,0 +1,41 @@
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+LOGS_BASEPATH=$DIR/logs
+
+set -Eeuo pipefail
+
+DATE_NOW=$(date +"%Y-%m-%d-%H%M")
+
+source $DIR/common.sh
+source $PYTHON_VENV_PATH/bin/activate
+
+LOGFILE=$LOGS_BASEPATH/otd_compare_gtfs_rt_static-$DATE_NOW.log
+touch "$LOGFILE"
+
+# '|| :' at end is to ignore failures
+echo "Step 1/2: running cli_compare_latest.py ..."
+python3 $DIR/../gtfs-rt-static-compare/cli_compare_latest.py >>"$LOGFILE" 2>>"$LOGFILE" || :
+echo ""
+
+status=0
+echo "Step 2/2: running cli_aggregate_monthly_reports_json.py ..."
+python3 $DIR/../gtfs-rt-static-compare/cli_aggregate_monthly_reports_json.py >>"$LOGFILE" 2>>"$LOGFILE" || status=$?
+echo ""
+symlink_latest $LOGFILE
+
+if [ "$status" -ne 0 ]; then
+  {
+    echo "From: $DEFAULT_MAIL_FROM"
+    echo "To: $GTFS_RT_STATIC_COMPARE_MAIL_TO"
+    echo "Subject: GTFS-RT -static compare issue"
+    echo "Content-Type: text/plain; charset=UTF-8"
+    echo
+    echo "Report: https://tools.odpch.ch/gtfs-rt-static-report/"
+    echo "Log: https://tools.odpch.ch/tmp/logs/otd_compare_gtfs_rt_static-LATEST.log"
+    echo
+    echo "-> last 50 rows"
+    echo
+    echo " ....................................................... "
+    tail -n 50 "$LOGFILE"
+  } | /usr/sbin/sendmail -t
+  exit "$status"
+fi

--- a/tools/scripts/common.sh
+++ b/tools/scripts/common.sh
@@ -1,5 +1,12 @@
 COMMON_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
+set -a
+
+source "$COMMON_DIR/.env"
+if [ -f "$COMMON_DIR/.env.local" ]; then
+  source "$COMMON_DIR/.env.local"
+fi
+
 _strip_filename_yyymmdd() {
     local file="$1"
     echo "$file" | sed -E 's/(.*)-[0-9]{4}-[0-9]{2}-[0-9]{2}.*/\1/'


### PR DESCRIPTION
- for each hourly report compute compare info based on the past working days at the same hour
- use only working days and non-holidays - generate these and keep them in config 
- send emails if the current number of GTFS-RT items drops below 10% mean value compared with the past 10 measurements
- updates GUI 
  - fetch also previous month for comparison
  - fixed table with scrollable day rows / hour columns
  - add possibility to show only working hours (6-18)
  - show previous days used for mean computation