### PR TITLE
Improve gtfs-rt -static compare logic

### DIFF
--- a/apps/gtfs-rt-static-report/src/app/app.component.html
+++ b/apps/gtfs-rt-static-report/src/app/app.component.html
@@ -105,8 +105,8 @@
                   <td>{{ computeDetailLookupValue('gtfs_rt_age') }}"</td>
                 </tr>
                 <tr>
-                  <th scope="row">{{ computeDetailLookupCaption('total_rows_no') }}</th>
-                  <td>{{ computeDetailLookupValue('total_rows_no') }}</td>
+                  <th scope="row">{{ computeDetailLookupCaption('total_active_rows_no') }}</th>
+                  <td>{{ computeDetailLookupValue('total_active_rows_no') }}</td>
                 </tr>
                 <!-- TODO - fix the -1 hack -->
                 <ng-container *ngIf="this.model.selectedReportCell.compareMetadata?.meanValueF !== '-1'">

--- a/apps/gtfs-rt-static-report/src/app/app.component.html
+++ b/apps/gtfs-rt-static-report/src/app/app.component.html
@@ -122,9 +122,17 @@
                     </td>
                   </tr>
                   <tr>
+                    <th scope="row">DropLine</th>
+                    <td>
+                      <div>
+                        <strong>5%:</strong> {{ this.model.selectedReportCell.compareMetadata?.dropLineF }}
+                      </div>
+                    </td>
+                  </tr>
+                  <tr>
                     <td colspan="2">
                       <div>
-                        <strong>DropLine (5%):</strong> {{ this.model.selectedReportCell.compareMetadata?.dropLineF }}
+                        <strong>Prev Values:</strong>
                       </div>
                       <hr/>
                       <ul>

--- a/apps/gtfs-rt-static-report/src/app/app.component.html
+++ b/apps/gtfs-rt-static-report/src/app/app.component.html
@@ -128,7 +128,7 @@
                       </div>
                       <hr/>
                       <ul>
-                        <ng-container *ngFor="let prevDayReportLine of this.model.selectedReportCell.compareMetadata?.reportLines">
+                        <ng-container *ngFor="let prevDayReportLine of this.model.selectedReportCell.compareMetadata?.reportLines?.reverse()">
                           <li>{{ prevDayReportLine }}</li>
                         </ng-container>
                       </ul>

--- a/apps/gtfs-rt-static-report/src/app/app.component.html
+++ b/apps/gtfs-rt-static-report/src/app/app.component.html
@@ -124,7 +124,7 @@
                   <tr>
                     <td colspan="2">
                       <div>
-                        <strong>DropLine:</strong> {{ this.model.selectedReportCell.compareMetadata?.dropLineF }}
+                        <strong>DropLine (5%):</strong> {{ this.model.selectedReportCell.compareMetadata?.dropLineF }}
                       </div>
                       <hr/>
                       <ul>

--- a/apps/gtfs-rt-static-report/src/app/app.component.html
+++ b/apps/gtfs-rt-static-report/src/app/app.component.html
@@ -111,7 +111,7 @@
                 <!-- TODO - fix the -1 hack -->
                 <ng-container *ngIf="this.model.selectedReportCell.compareMetadata?.meanValueF !== '-1'">
                   <tr>
-                    <th scope="row">Previous Total Trips</th>
+                    <th scope="row">Previous Values</th>
                     <td>
                       <div>
                         <strong>Value:</strong> {{ this.model.selectedReportCell.compareMetadata?.valueF }}
@@ -119,6 +119,10 @@
                       <div>
                         <strong>Mean:</strong> {{ this.model.selectedReportCell.compareMetadata?.meanValueF }}
                       </div>
+                    </td>
+                  </tr>
+                  <tr>
+                    <td colspan="2">
                       <div>
                         <strong>DropLine:</strong> {{ this.model.selectedReportCell.compareMetadata?.dropLineF }}
                       </div>
@@ -128,10 +132,13 @@
                           <li>{{ prevDayReportLine }}</li>
                         </ng-container>
                       </ul>
-                      
                     </td>
                   </tr>
                 </ng-container>
+                <tr>
+                  <th scope="row">{{ computeDetailLookupCaption('total_rows_no') }}</th>
+                  <td>{{ computeDetailLookupValue('total_rows_no') }}</td>
+                </tr>
                 <tr>
                   <th scope="row">{{ computeDetailLookupCaption('tripOK_routeOK_no') }}</th>
                   <td>{{ computeDetailLookupValue('tripOK_routeOK_no') }}</td>

--- a/apps/gtfs-rt-static-report/src/app/app.component.ts
+++ b/apps/gtfs-rt-static-report/src/app/app.component.ts
@@ -14,7 +14,7 @@ interface HourCell {
   hourF: string
 }
 
-type ReportValueLookupType = 'gtfs_db_age' | 'gtfs_rt_age' | 'total_rows_no' | 'tripOK_routeOK_no' | 'tripOK_routeNOK_no' | 'tripNOK_routeOK_no' | 'tripNOK_routeNOK_no' | 'tripNOK_NOJP_no'
+type ReportValueLookupType = 'gtfs_db_age' | 'gtfs_rt_age' | 'total_rows_no' | 'total_active_rows_no' | 'tripOK_routeOK_no' | 'tripOK_routeNOK_no' | 'tripNOK_routeOK_no' | 'tripNOK_routeNOK_no' | 'tripNOK_NOJP_no'
 
 interface ReportValueLookup {
   type: ReportValueLookupType,
@@ -94,6 +94,7 @@ const mapReportValueLookups: Record<ReportValueLookupType, string> = {
   gtfs_db_age: 'GTFS-DB Age',
   gtfs_rt_age: 'GTFS-RT Age',
   total_rows_no: 'GTFS-RT Total Trips No',
+  total_active_rows_no: 'GTFS-RT Total Active Trips No',
   tripOK_routeOK_no: 'Matched Trips',
   tripOK_routeNOK_no: 'Matched Trips / Not-matched Routes',
   tripNOK_routeOK_no: 'Not-matched Trips / Matched Routes',
@@ -104,7 +105,7 @@ const mapReportValueLookups: Record<ReportValueLookupType, string> = {
 const reportValueLookups = (() => {
   const lookups: ReportValueLookup[] = [];
 
-  const reportValueLookupTypes: ReportValueLookupType[] = ['total_rows_no', 'gtfs_db_age', 'gtfs_rt_age', 'tripOK_routeOK_no', 'tripOK_routeNOK_no', 'tripNOK_routeOK_no', 'tripNOK_routeNOK_no', 'tripNOK_NOJP_no'];
+  const reportValueLookupTypes: ReportValueLookupType[] = ['total_active_rows_no', 'total_rows_no', 'gtfs_db_age', 'gtfs_rt_age', 'tripOK_routeOK_no', 'tripOK_routeNOK_no', 'tripNOK_routeOK_no', 'tripNOK_routeNOK_no', 'tripNOK_NOJP_no'];
 
   reportValueLookupTypes.forEach(reportValueLookupType => {
     const lookup: ReportValueLookup = {
@@ -374,7 +375,7 @@ export class AppComponent {
                   const compareMetadata: GTFS_RT_StaticReportCompareMetadata = {
                     info: compare_info,
                     reportLines: compareReportLines,
-                    valueF: '' + (reportAny['total_rows_no'] ?? 0),
+                    valueF: '' + (reportAny['total_active_rows_no'] ?? 0),
                     meanValueF: '' + compare_info.mean_value,
                     dropLineF: '' + compare_info.drop_line,
                   };

--- a/apps/gtfs-rt-static-report/src/app/app.component.ts
+++ b/apps/gtfs-rt-static-report/src/app/app.component.ts
@@ -377,7 +377,7 @@ export class AppComponent {
                     reportLines: compareReportLines,
                     valueF: '' + (reportAny['total_active_rows_no'] ?? 0),
                     meanValueF: '' + compare_info.mean_value,
-                    dropLineF: '' + compare_info.drop_line,
+                    dropLineF: '' + Math.round(Number(compare_info.drop_line)),
                   };
 
                   reportCell.compareMetadata = compareMetadata;

--- a/apps/gtfs-rt-static-report/src/app/app.component.ts
+++ b/apps/gtfs-rt-static-report/src/app/app.component.ts
@@ -173,7 +173,7 @@ export class AppComponent {
       selectedReportMapPrevKeys: {},
     };
     this.updateHourCells();
-
+  }
 
   async ngOnInit(): Promise<void> {
     await this.fetchAndUpdateReport();

--- a/apps/gtfs-rt-static-report/src/app/app.component.ts
+++ b/apps/gtfs-rt-static-report/src/app/app.component.ts
@@ -168,7 +168,7 @@ export class AppComponent {
       hourCells: [],
       reportValueLookups: reportValueLookups,
       selectedReportValueLookup: reportValueLookups[0],
-      appVersion: '20250905.1',
+      appVersion: '20251029.1',
       showAllHours: false,
       reportLastUpdateF: 'n/a',
       selectedReportMapPrevKeys: {},

--- a/tools/gtfs-rt-static-compare/cli_aggregate_monthly_reports_json.py
+++ b/tools/gtfs-rt-static-compare/cli_aggregate_monthly_reports_json.py
@@ -88,7 +88,7 @@ def _compute_compare(app_config: Any, report_key: str, map_hr_report: dict[str, 
     if has_prev_data and is_relevant:
         prev_values = compare_info.map_days.values()
         measure_mean = median(prev_values)
-        drop_line = measure_mean * (1 - 0.1)
+        drop_line = measure_mean * (1 - 0.05)
         
         report = map_hr_report[report_key]
         report_value = report.total_active_rows_no

--- a/tools/gtfs-rt-static-compare/cli_aggregate_monthly_reports_json.py
+++ b/tools/gtfs-rt-static-compare/cli_aggregate_monthly_reports_json.py
@@ -56,17 +56,22 @@ def _compute_compare(app_config: Any, report_key: str, map_hr_report: dict[str, 
     while days_back_idx < days_back_max:
         prev_report_day -= timedelta(days=1)
         
-        prev_report_key = f'{prev_report_day}-{report_hr_f}'
+        prev_report_day_f = f'{prev_report_day}'
+        ignore_dropline_error = prev_report_day_f in app_config['map_days_ignore_dropline_error']
+        
+        prev_report_key = f'{prev_report_day_f}-{report_hr_f}'
         if prev_report_key in map_hr_report:
             prev_compare = map_compare.get(prev_report_key, None)
         
-            is_prev_working_day = False
+            include_dropline_computation = False
             if prev_compare is not None:
                 if prev_compare.compare_type == 'w':
-                    is_prev_working_day = True
+                    include_dropline_computation = True
+                if (prev_compare.compare_type == 'w_p') and ignore_dropline_error:
+                    include_dropline_computation = True
             # check if prev compare is working day
             
-            if is_prev_working_day:
+            if include_dropline_computation:
                 prev_total_rows_no = map_hr_report[prev_report_key].total_rows_no
                 compare_info.map_days[f'{prev_report_day}'] = prev_total_rows_no
             # if

--- a/tools/gtfs-rt-static-compare/cli_aggregate_monthly_reports_json.py
+++ b/tools/gtfs-rt-static-compare/cli_aggregate_monthly_reports_json.py
@@ -72,8 +72,8 @@ def _compute_compare(app_config: Any, report_key: str, map_hr_report: dict[str, 
             # check if prev compare is working day
             
             if include_dropline_computation:
-                prev_total_rows_no = map_hr_report[prev_report_key].total_rows_no
-                compare_info.map_days[f'{prev_report_day}'] = prev_total_rows_no
+                prev_day_value = map_hr_report[prev_report_key].total_active_rows_no
+                compare_info.map_days[f'{prev_report_day}'] = prev_day_value
             # if
         # check if we have report
         
@@ -91,18 +91,18 @@ def _compute_compare(app_config: Any, report_key: str, map_hr_report: dict[str, 
         drop_line = measure_mean * (1 - 0.1)
         
         report = map_hr_report[report_key]
-        report_total_rows_no = report.total_rows_no
+        report_value = report.total_active_rows_no
         
         compare_info.drop_line = drop_line
         compare_info.mean_value = measure_mean
         
-        if report_total_rows_no < drop_line:
+        if report_value < drop_line:
             compare_info.compare_type = 'w_p'
             
             if is_verbose_mode:
                 print(f'possible issue:')
                 print(f'  {report_ymd_f} {report_hr_f}:00')
-                print(f'  rows      : {report_total_rows_no}')
+                print(f'  rows      : {report_value}')
                 print(f'  drop_line : {drop_line}')
                 print()
                 

--- a/tools/gtfs-rt-static-compare/cli_batch_compare.py
+++ b/tools/gtfs-rt-static-compare/cli_batch_compare.py
@@ -15,7 +15,8 @@ def main():
     app_path = Path(os.path.realpath(__file__)).parent
     
     report_now = datetime.now()
-    report_date_filter = report_now.strftime('%Y-%m')
+    # default is current day
+    report_date_filter = report_now.strftime('%Y-%m-%d')
     
     parser = argparse.ArgumentParser()
     parser.add_argument('--filter', '--filter', default=report_date_filter)

--- a/tools/gtfs-rt-static-compare/compare_gtfs_rt_static/gtfs_controller.py
+++ b/tools/gtfs-rt-static-compare/compare_gtfs_rt_static/gtfs_controller.py
@@ -194,6 +194,8 @@ class GTFS_Controller:
             gtfs_rt_age=gtfs_rt_age,
     
             total_rows_no=0,
+            total_active_rows_no=0,
+            
             tripOK_routeOK_no=0,
             tripOK_routeNOK_no=0,
             tripNOK_routeOK_no=0,
@@ -211,6 +213,12 @@ class GTFS_Controller:
             
             trip_OK = trip_id in gtfs_db.map_trips
             route_OK = route_id in gtfs_db.map_routes
+            
+            from_date_f = entity.tripUpdate.trip.startDate + ' ' +  entity.tripUpdate.trip.startTime
+            from_date = datetime.strptime(from_date_f, '%Y%m%d %H:%M:%S')
+
+            if from_date > report_dt:
+                report_stats.metadata.total_active_rows_no += 1
             
             if trip_OK and route_OK:
                 report_stats.metadata.tripOK_routeOK_no += 1

--- a/tools/gtfs-rt-static-compare/compare_gtfs_rt_static/gtfs_controller.py
+++ b/tools/gtfs-rt-static-compare/compare_gtfs_rt_static/gtfs_controller.py
@@ -238,7 +238,7 @@ class GTFS_Controller:
                 # catch '20250930 24:01:00' ->
                 from_date = from_date + timedelta(days=1)
 
-            if from_date > report_dt:
+            if from_date < report_dt:
                 report_stats.metadata.total_active_rows_no += 1
             
             if trip_OK and route_OK:

--- a/tools/gtfs-rt-static-compare/compare_gtfs_rt_static/gtfs_controller.py
+++ b/tools/gtfs-rt-static-compare/compare_gtfs_rt_static/gtfs_controller.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 from typing import Union
 
-from datetime import datetime
+from datetime import datetime, timedelta
 
 import gzip
 import shutil
@@ -24,6 +24,23 @@ from .fetch import fetch_latest, compute_resource_snapshot_path
 
 gtfs_rt_static_report_file_regexp = r"gtfs_rt_static_report-([0-9]{4})-([0-9]{2})-([0-9]{2})-([0-9]{2})([0-9]{2})"
 header_separator_s = '-' * 60
+
+def normalize_if_overflow(t: str) -> tuple[str, bool]:
+    """
+    Detect if a time string (HH:MM:SS) exceeds 23:59:59.
+    If overflow, return normalized time (wrapped to next day) and True.
+    Otherwise, return original time and False.
+    """
+    h, m, s = map(int, t.split(':'))
+    total_seconds = h * 3600 + m * 60 + s
+
+    if total_seconds >= 24 * 3600:
+        total_seconds %= 24 * 3600
+        h, rem = divmod(total_seconds, 3600)
+        m, s = divmod(rem, 60)
+        return f'{h:02d}:{m:02d}:{s:02d}', True
+    else:
+        return t, False
 class GTFS_Controller:
     def __init__(self, app_path: Path):
         config_path = Path(f'{app_path}/config/config.yml')
@@ -214,8 +231,12 @@ class GTFS_Controller:
             trip_OK = trip_id in gtfs_db.map_trips
             route_OK = route_id in gtfs_db.map_routes
             
-            from_date_f = entity.tripUpdate.trip.startDate + ' ' +  entity.tripUpdate.trip.startTime
+            from_date_start_time, overflow = normalize_if_overflow(entity.tripUpdate.trip.startTime)
+            from_date_f = entity.tripUpdate.trip.startDate + ' ' +  from_date_start_time
             from_date = datetime.strptime(from_date_f, '%Y%m%d %H:%M:%S')
+            if overflow:
+                # catch '20250930 24:01:00' ->
+                from_date = from_date + timedelta(days=1)
 
             if from_date > report_dt:
                 report_stats.metadata.total_active_rows_no += 1

--- a/tools/gtfs-rt-static-compare/compare_gtfs_rt_static/models/gtfs_rt_static_report.py
+++ b/tools/gtfs-rt-static-compare/compare_gtfs_rt_static/models/gtfs_rt_static_report.py
@@ -27,6 +27,7 @@ class GTFS_RT_Static_Report_Metadata:
     gtfs_rt_age: int
     
     total_rows_no: int
+    total_active_rows_no: int
     # Trip/Route matched with GTFS
     tripOK_routeOK_no: int
     
@@ -41,7 +42,10 @@ class GTFS_RT_Static_Report_Metadata:
     tripNOK_NOJP_no: int
     
     @staticmethod
-    def from_json(data_json):
+    def from_json(data_json: dict[str, Any]):
+        if data_json.get('total_active_rows_no') is None:
+            data_json['total_active_rows_no'] = 0
+        
         metadata = GTFS_RT_Static_Report_Metadata(**data_json)
         metadata.report_dt = datetime.strptime(data_json['report_dt'], '%Y-%m-%d %H:%M:%S')
         metadata.gtfs_rt_dt = datetime.strptime(data_json['gtfs_rt_dt'], '%Y-%m-%d %H:%M:%S')

--- a/tools/gtfs-rt-static-compare/config/config.yml
+++ b/tools/gtfs-rt-static-compare/config/config.yml
@@ -16,6 +16,7 @@ map_days_ignore_dropline_error:
   "2025-10-23": yes
   "2025-10-24": yes
   "2025-10-27": yes
+  "2025-10-28": yes
 
 # TODO - needs to be generated
 map_holidays:

--- a/tools/gtfs-rt-static-compare/config/config.yml
+++ b/tools/gtfs-rt-static-compare/config/config.yml
@@ -11,6 +11,12 @@ resource_paths:
 opentransportdata:
   gtfs_rt_url: https://api.opentransportdata.swiss/la/gtfs-rt?format=JSON
 
+# following days are still included in drop line computation even though they had errors
+map_days_ignore_dropline_error:
+  "2025-10-23": yes
+  "2025-10-24": yes
+  "2025-10-27": yes
+
 # TODO - needs to be generated
 map_holidays:
   # 2024

--- a/tools/gtfs-rt-static-compare/config/config.yml
+++ b/tools/gtfs-rt-static-compare/config/config.yml
@@ -13,10 +13,8 @@ opentransportdata:
 
 # following days are still included in drop line computation even though they had errors
 map_days_ignore_dropline_error:
-  "2025-10-23": yes
-  "2025-10-24": yes
-  "2025-10-27": yes
-  "2025-10-28": yes
+  # "2025-10-23": yes
+  "foo": "yes"
 
 # TODO - needs to be generated
 map_holidays:

--- a/tools/gtfs-rt-static-compare/docs/gtfs-rt-static-compare.md
+++ b/tools/gtfs-rt-static-compare/docs/gtfs-rt-static-compare.md
@@ -60,23 +60,24 @@ Example for 25.May 2024 10:00
 https://tools.odpch.ch/gtfs-rt-snapshot/2024/05/25/GTFS_RT-2024-05-25-1000.json
 ```
 - the GTFS-RT items are compared against latest GTFS-static DB file
-- a matching report is generated, example for `25.May 2024 10:00`:  [gtfs_rt_static_report-2024-05-25-1000.json](view-source:https://tools.odpch.ch/gtfs-rt-static-compare-report/2024/05/25/gtfs_rt_static_report-2024-05-25-1000.json)
+- a matching report is generated, example for `10.October 2025 10:00`:  [gtfs_rt_static_report-2025-10-10-1000.json](view-source:https://tools.odpch.ch/gtfs-rt-static-compare-report/2025/10/10/gtfs_rt_static_report-2025-10-10-1000.json)
 
 ```
 {
   "metadata": {
-    "report_dt": "2024-05-25 10:00:00",
-    "gtfs_db_filename": "gtfs_2024-05-23.sqlite",
-    "gtfs_db_age": 1.98,
-    "gtfs_rt_filename": "GTFS_RT-2024-05-25-1000.json",
-    "gtfs_rt_ts": 1716623989,
-    "gtfs_rt_dt": "2024-05-25 09:59:49",
-    "gtfs_rt_age": -11,
-    "total_rows_no": 10669,
-    "tripOK_routeOK_no": 9543,
+    "report_dt": "2025-10-10 10:00:00",
+    "gtfs_db_filename": "gtfs_2025-10-09.sqlite",
+    "gtfs_db_age": 0.74,
+    "gtfs_rt_filename": "GTFS_RT-2025-10-10-1000.json.gz",
+    "gtfs_rt_ts": 1760083197,
+    "gtfs_rt_dt": "2025-10-10 09:59:57",
+    "gtfs_rt_age": -3,
+    "total_rows_no": 14619,
+    "total_active_rows_no": 4468,
+    "tripOK_routeOK_no": 13536,
     "tripOK_routeNOK_no": 0,
-    "tripNOK_routeOK_no": 891,
-    "tripNOK_routeNOK_no": 235,
+    "tripNOK_routeOK_no": 543,
+    "tripNOK_routeNOK_no": 540,
     "tripNOK_NOJP_no": 0
   },
   "tripOK_routeNOK": [],
@@ -110,6 +111,7 @@ Schema
 | gtfs_rt_dt | GTFS-RT datetime |  |
 | gtfs_rt_age | Difference in seconds between GTFS-RT `Header.TimestampUpdated` and report datetime | Abs values bigger than 60(seconds) may refer to data-freshness of the feed, i.e. cache-issues |
 | total_rows_no | Total number of GTFS-RT `Entity` items | This number varies between 2k to 15k entries during normal hours (day) |
+| total_active_rows_no | Total number of active GTFS-RT `Entity` items | Active Item = item that has the `tripUpdate.trip.startDate` + `startTime` before report time |
 | tripOK_routeOK_no | Total number of matched trips against GTFS-static | This number should be close to `total_rows_no` |
 | tripOK_routeNOK_no | Total number of matched trips against GTFS-static but without a valid route match. | This should be 0, otherwise there are issues in the datatset |
 | tripNOK_routeOK_no | Total number of not-matched trips against GTFS-static but with a valid route match | This should be a small number and the `tripNOK_routeOK` list should contain only `ojp:` prefixed entries |
@@ -118,11 +120,11 @@ Schema
 
 ## GTFS-RT - GTFS-static monthly comparison reports
 - the hourly reports are consolidated in a monthly report
-- i.e. for May 2024 - https://tools.odpch.ch/gtfs-rt-static-compare-report/2024/gtfs_rt_static_report-2024-05.json
+- i.e. for October 2025 - https://tools.odpch.ch/gtfs-rt-static-compare-report/2025/gtfs_rt_static_report-2025-10.json
 - the report is visualised via https://tools.odpch.ch/gtfs-rt-static-report/
 - each day/hr can be inspected and the individual reports to be checked
 - previous months can be loaded
-- by default `total_rows_no` (total number of GTFS-RT feed items) is shown in the report cells but other metadata keys can be chosen
+- by default `total_active_rows_no` (total number of GTFS-RT **active** feed items) is shown in the report cells but other metadata keys can be chosen
 - for each cell following error types can be shown
 
 | Error | Description | Possible cause of error |
@@ -130,4 +132,4 @@ Schema
 | `Match` | GTFS-RT snapshot is not in sync with the GTFS-static DB | The GTFS-static dataset wasnt published, however GTFS-RT feed is using the new dataset. |
 | `DATA` | GTFS-RT snapshot is missing | The GTFS-RT server returns an invalid response |
 | `RT age` | GTFS-RT `Header.TimestampUpdated` is considerably older than the report date | The GTFS-RT server returns a cached / outdated response |
-
+| `Drop` | `total_active_rows_no` dropped below mean value of the prev 10 days measurements done at the same hour. Only workdays are checked. | Agencies are publishing a smaller number of GTFS-RT messages |

--- a/tools/gtfs-static-db-importer/data/ckan-utils-tmp
+++ b/tools/gtfs-static-db-importer/data/ckan-utils-tmp
@@ -1,1 +1,1 @@
-../../ckan-utils/tmp
+../../../data/ckan-utils-tmp


### PR DESCRIPTION
- use `total_active_rows_no` - total active GTFS-RT items to compare prev values
  - active: a GTFS item that has `tripUpdate.trip.startDate` + `startTime` before report time - meaning the service started before reported time
- use 5% drop line, update [gtfs-rt-static-compare.md](./tools/gtfs-rt-static-compare/docs/gtfs-rt-static-compare.md) docs