### PR TITLE
Update scripts

### DIFF
--- a/tools/atlas-geocode-lines/README.md
+++ b/tools/atlas-geocode-lines/README.md
@@ -59,7 +59,7 @@ Current GeoJSON https://tools.odpch.ch/data/atlas_stops.geojson
 $ npm install
 
 # build
-$ npx tsc
+$ npm run build
 
 # execute program
 $ node --import=specifier-resolution-node/register dist/index.js

--- a/tools/atlas-geocode-lines/src/constants.ts
+++ b/tools/atlas-geocode-lines/src/constants.ts
@@ -12,6 +12,11 @@ export const OJP_STAGE_CONFIG: OJP.HTTPConfig = {
   authToken: '', // override with another key
 };
 
+if (!OJP_STAGE_CONFIG.authToken) {
+  console.log('OJP_STAGE_CONFIG token is missing');
+  process.exit(1);
+}
+
 // sleep interval between 2 OJP requests, the default key is limited to 50requests / minute
 // @see https://opentransportdata.swiss/en/limits-and-costs/
 export const OJP_REQUESTS_SLEEP_MS = 1200;

--- a/tools/scripts/cli_otd_compare_gtfs_rt_static.sh
+++ b/tools/scripts/cli_otd_compare_gtfs_rt_static.sh
@@ -1,6 +1,6 @@
-DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
-
 set -Eeuo pipefail
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
 DATE_NOW=$(date +"%Y-%m-%d-%H%M")
 

--- a/tools/scripts/cli_otd_fetch_atlas.sh
+++ b/tools/scripts/cli_otd_fetch_atlas.sh
@@ -1,3 +1,5 @@
+set -Eeuo pipefail
+
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
 DATE_NOW=$(date +"%Y-%m-%d")

--- a/tools/scripts/cli_otd_fetch_bo.sh
+++ b/tools/scripts/cli_otd_fetch_bo.sh
@@ -1,3 +1,5 @@
+set -Eeuo pipefail
+
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
 DATE_NOW=$(date +"%Y-%m-%d")

--- a/tools/scripts/cli_otd_process_gtfs.sh
+++ b/tools/scripts/cli_otd_process_gtfs.sh
@@ -1,3 +1,5 @@
+set -Eeuo pipefail
+
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
 DATE_NOW=$(date +"%Y-%m-%d")

--- a/tools/scripts/cli_otd_process_hrdf.sh
+++ b/tools/scripts/cli_otd_process_hrdf.sh
@@ -1,3 +1,5 @@
+set -Eeuo pipefail
+
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
 DATE_NOW=$(date +"%Y-%m-%d")


### PR DESCRIPTION
- fail early in the bash scripts
- check and fail early if stage token is not set for `atlas-geocode-lines` tool