### PR TITLE
Improve GTFS -RT / -static comparison

### DIFF
--- a/apps/gtfs-query/inc/config.yml
+++ b/apps/gtfs-query/inc/config.yml
@@ -5,8 +5,6 @@ gtfs_dbs_catalog_path: "[APP_PATH]/data/gtfs-static-dbs/gtfs-static-dbs.json"
 
 # https://opentransportdata.swiss/en/dataset/business-organisations
 business_organisation_latest_path: "[APP_PATH]/data/opentransportdata.swiss/business-organisations/actual-date-business-organisation_LATEST.csv"
-# https://opentransportdata.swiss/de/dataset/go-realtime
-go_realtime_csv_path: "[APP_PATH]/data/opentransportdata.swiss/go-realtime/go-realtime.csv"
 
 map_sql_queries:
     # select

--- a/apps/gtfs-query/inc/gtfs_db_controller.php
+++ b/apps/gtfs-query/inc/gtfs_db_controller.php
@@ -270,7 +270,8 @@ class GTFS_DB_Controller {
     private function compute_agency_ids_sql_filter($filter_agency_ids) {
         $agency_ids = $filter_agency_ids;
         if (in_array('HAS_GTFS_RT', $agency_ids)) {
-            $agency_ids = $this->load_agency_ids_from_csv();
+            $agency_ids_sql_filter = "AND link_agency.has_gtfs_rt = 1";
+            return $agency_ids_sql_filter;
         }
 
         if (empty($agency_ids)) {

--- a/apps/gtfs-query/inc/gtfs_db_controller.php
+++ b/apps/gtfs-query/inc/gtfs_db_controller.php
@@ -12,7 +12,6 @@ class GTFS_DB_Controller {
     var $cache_prefix;
 
     var $map_sql_queries;
-    var $go_realtime_csv_path;
     var $app_db_cache_path;
 
     var $sql_builder_config;
@@ -44,7 +43,6 @@ class GTFS_DB_Controller {
         $this->db = new SQLite3($gtfs_db_path, SQLITE3_OPEN_READONLY);
 
         $this->map_sql_queries = $config['map_sql_queries'];
-        $this->go_realtime_csv_path = $config['go_realtime_csv_path'];
         $this->app_db_cache_path = $config['app_db_cache_path'];
 
         $this->use_cache = TRUE;
@@ -305,39 +303,6 @@ class GTFS_DB_Controller {
         }
 
         return $csv_file;
-    }
-
-    private function load_agency_ids_from_csv() {
-        $agency_ids = array();
-
-        $go_realtime_csv_path = $this->go_realtime_csv_path;
-        $csv_file = $this->_load_csv_file($go_realtime_csv_path);
-
-        $csv_headers = fgetcsv($csv_file, null, ';');
-        if (!$csv_headers) {
-            die('empty CSV headers found for load_agency_ids_from_csv()');
-        }
-
-        while (is_array($row = fgetcsv($csv_file, 1000, ';'))) {
-            $csv_row = array_combine($csv_headers, $row);
-
-            $sboid = $csv_row['sboid'];
-            if (in_array($sboid, $this->map_business_organisations)) {
-                $agency_id = $this->map_business_organisations[$sboid];
-            } else {
-                $vdv_BetreiberIdParts = explode(':', $csv_row['vdvBetreiberId']);
-                $agency_id = $vdv_BetreiberIdParts[1];
-            }
-            
-            array_push($agency_ids, $agency_id);
-        }
-
-        fclose($csv_file);
-
-        // filter out null or empty string values
-        $agency_ids = array_filter($agency_ids);
-
-        return $agency_ids;
     }
 
     public function query_table($table_name) {

--- a/apps/gtfs-rt-static-report/angular.json
+++ b/apps/gtfs-rt-static-report/angular.json
@@ -33,7 +33,9 @@
               "node_modules/bootstrap/dist/css/bootstrap.min.css",
               "src/styles.scss"
             ],
-            "scripts": []
+            "scripts": [
+              "node_modules/bootstrap/dist/js/bootstrap.bundle.min.js"
+            ]
           },
           "configurations": {
             "production": {

--- a/apps/gtfs-rt-static-report/package-lock.json
+++ b/apps/gtfs-rt-static-report/package-lock.json
@@ -13343,6 +13343,7 @@
       "integrity": "sha512-5hbAst3h3C3L8w6W4P96L5vaV0PxSmJhxZvWKYIdgxOQm8pNZ5dEOmmSLBVpP85ReeyRt6AS1QJNyo/oFFPeVA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/bonjour": "^3.5.9",
         "@types/connect-history-api-fallback": "^1.3.5",

--- a/apps/gtfs-rt-static-report/src/app/data.service.ts
+++ b/apps/gtfs-rt-static-report/src/app/data.service.ts
@@ -2,7 +2,7 @@ import { HttpClient } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 import { firstValueFrom } from 'rxjs';
 
-import { GTFS_RT_Static_Monthly_Report_JSON } from './types/_all';
+import { GTFS_RT_Static_Monthly_Report_JSON, GTFS_RT_Static_Report } from './types/_all';
 import { Response_GTFS_RT } from './models/gtfs-rt/gtfs-rt-response';
 import { GTFS_DB_LookupAgency, GTFS_DB_LookupRoutes } from './models/gtfs/gtfs';
 
@@ -28,6 +28,11 @@ export class DataService {
   public async fetchGTFS_RT_Snapshot(url: string): Promise<Response_GTFS_RT> {
     const gtfsRT_SnapshotJSON = await firstValueFrom(this.http.get<Response_GTFS_RT>(url));
     return gtfsRT_SnapshotJSON;
+  }
+
+  public async fetchGTFS_RT_StaticReport(url: string): Promise<GTFS_RT_Static_Report> {
+    const json = await firstValueFrom(this.http.get<GTFS_RT_Static_Report>(url));
+    return json;
   }
 
   // https://tools.opentransportdata.swiss/gtfs-query/lookup/routes?gtfs_day=2026-03-07

--- a/apps/gtfs-rt-static-report/src/app/detail-agency.component.html
+++ b/apps/gtfs-rt-static-report/src/app/detail-agency.component.html
@@ -4,18 +4,8 @@
   </header>
 
   <div class="flex-grow-1 d-flex flex-column overflow-hidden pt-3 ps-3 pe-3">
-    <div class="d-flex mb-2 align-items-center">
-      <div>Compare with </div>
-      <div class="mx-1"></div>
-      <div>
-        <select 
-          class="form-select form-control form-control-sm" 
-          [(ngModel)]="this.model.prevKeyB" 
-          (ngModelChange)="onCompareValueChange()">
-          <option *ngFor="let compareKey of this.model.compareKeys" [ngValue]="compareKey">{{ compareKey }}</option>
-        </select>
-      </div>
-      <div class="ms-auto"><a [routerLink]="'/home'">Back to Home</a></div>
+    <div class="d-flex align-items-center">
+      <div><a [routerLink]="'/home'">← MonthlyReport</a></div>
     </div>
 
     <div class="d-flex overflow-auto mb-1">

--- a/apps/gtfs-rt-static-report/src/app/detail-agency.component.html
+++ b/apps/gtfs-rt-static-report/src/app/detail-agency.component.html
@@ -15,9 +15,15 @@
         <table class="table table-hover table-bordered table-striped sticky-report">
           <thead>
             <tr class="align-middle bottom-thick">
-              <th class="col" style="max-width: 200px;">id</th>
-              <th class="left-thick" scope="col col-sortable" (click)="onSortClick('name')">agency name</th>
-              <th class="left-thick" scope="col col-sortable" (click)="onSortClick('keyA')" style="width: 200px">{{ this.model.keyA }} <br/> GTFS-RT / -static</th>
+              <th class="col" style="max-width: 200px;">Id</th>
+              <th class="left-thick hint" scope="col col-sortable" (click)="onSortClick('name')">
+                <span>Name</span>
+                <ng-container *ngTemplateOutlet="sortIcon; context: { column: 'name' }"></ng-container>
+              </th>
+              <th class="left-thick" scope="col col-sortable" (click)="onSortClick('keyA')" style="width: 200px">
+                {{ this.model.keyA }}
+                <ng-container *ngTemplateOutlet="sortIcon; context: { column: 'keyA' }"></ng-container>
+                <br/> GTFS-RT / -static</th>
               <th scope="col" style="width: 200px" class="left-thick">
                 <select 
                   class="form-select form-control form-control-sm" 
@@ -27,7 +33,14 @@
                 </select>
                 GTFS-RT / -static
               </th>
-              <th class="left-thick" scope="col col-sortable" (click)="onSortClick('diff')">diff</th>
+              <th class="left-thick" scope="col col-sortable" (click)="onSortClick('rt-diff')">
+                <span title="RT_active - RT_active_PREV">GTFS-RT diff</span>
+                <ng-container *ngTemplateOutlet="sortIcon; context: { column: 'rt-diff' }"></ng-container>
+              </th>
+              <th class="left-thick" scope="col col-sortable" (click)="onSortClick('delta-diff')">
+                <span title="ABS((static_active - RT_active) - (static_active_PREV - RT_active_PREV))">Delta diff</span>
+                <ng-container *ngTemplateOutlet="sortIcon; context: { column: 'delta-diff' }"></ng-container>
+              </th>
             </tr>
           </thead>
           <tbody>
@@ -42,7 +55,7 @@
                     <div class="ms-auto"><span class="badge rounded-pill" [ngClass]="reportRow.valueNow.coverageClass">{{ reportRow.valueNow.coverage }}%</span></div>
                   </div>
                   <div class="progress" style="height: 6px;">
-                    <div class="progress-bar progress-light" [style.width.%]="reportRow.valueNow.coverage"></div>
+                    <div class="progress-bar" [ngClass]="reportRow.valueNow.coverageClass" [style.width.%]="reportRow.valueNow.coverage"></div>
                   </div>
                 </td>
                 
@@ -52,11 +65,12 @@
                     <div class="ms-auto"><span class="badge rounded-pill" [ngClass]="reportRow.valuePrev.coverageClass">{{ reportRow.valuePrev.coverage }}%</span></div>
                   </div>
                   <div class="progress" style="height: 6px;">
-                    <div class="progress-bar progress-light" [style.width.%]="reportRow.valuePrev.coverage"></div>
+                    <div class="progress-bar" [ngClass]="reportRow.valuePrev.coverageClass" [style.width.%]="reportRow.valuePrev.coverage"></div>
                   </div>  
                 </td>
                 
-                <td class="left-thick">{{ reportRow.valueNow.gtfsRt - reportRow.valuePrev.gtfsRt }}</td>
+                <td class="left-thick">{{ reportRow.computed.rtDiff }}</td>
+                <td class="left-thick">{{ reportRow.computed.deltaDiff }}</td>
               </tr>
             </ng-container>
           </tbody>
@@ -76,4 +90,8 @@
   </footer>
 </div>
 
+<ng-template #sortIcon let-column="column">
+  <span *ngIf="this.model.sort.column === column && this.model.sort.direction === 'asc'">▲</span>
+  <span *ngIf="this.model.sort.column === column && this.model.sort.direction === 'desc'">▼</span>
+</ng-template>
 

--- a/apps/gtfs-rt-static-report/src/app/detail-agency.component.html
+++ b/apps/gtfs-rt-static-report/src/app/detail-agency.component.html
@@ -18,7 +18,6 @@
               <th class="col" style="max-width: 200px;">id</th>
               <th class="left-thick" scope="col col-sortable" (click)="onSortClick('name')">agency name</th>
               <th class="left-thick" scope="col col-sortable" (click)="onSortClick('keyA')" style="width: 200px">{{ this.model.keyA }} <br/> GTFS-RT / -static</th>
-              <th scope="col">Coverage</th>
               <th scope="col" style="width: 200px" class="left-thick">
                 <select 
                   class="form-select form-control form-control-sm" 
@@ -28,7 +27,6 @@
                 </select>
                 GTFS-RT / -static
               </th>
-              <th scope="col">Coverage</th>
               <th class="left-thick" scope="col col-sortable" (click)="onSortClick('diff')">diff</th>
             </tr>
           </thead>
@@ -37,20 +35,27 @@
               <tr>
                 <td>{{ reportRow.agency.agency_id }}</td>
                 <td class="left-thick">{{ reportRow.agency.agency_name }}</td>
+                
                 <td class="left-thick">
-                  <div class="mb-1">{{ reportRow.valueNow.gtfsRt }} / {{ reportRow.valueNow.gtfsStatic }}</div>
+                  <div class="mb-1 d-flex gap-2 align-items-center">
+                    <div>{{ reportRow.valueNow.gtfsRt }} / {{ reportRow.valueNow.gtfsStatic }}</div>
+                    <div class="ms-auto"><span class="badge rounded-pill" [ngClass]="reportRow.valueNow.coverageClass">{{ reportRow.valueNow.coverage }}%</span></div>
+                  </div>
                   <div class="progress" style="height: 6px;">
                     <div class="progress-bar progress-light" [style.width.%]="reportRow.valueNow.coverage"></div>
                   </div>
                 </td>
-                <td class="align-middle">{{ reportRow.valueNow.coverage }}%</td>
+                
                 <td class="left-thick">
-                  <div class="mb-1">{{ reportRow.valuePrev.gtfsRt }} / {{ reportRow.valuePrev.gtfsStatic }}</div>
-                  <div class="progress" style="height: 6px;">
-                    <div class="progress-bar progress-light" [style.width.%]="reportRow.valueNow.coverage"></div>
+                  <div class="mb-1 d-flex gap-2 align-items-center">
+                    <div>{{ reportRow.valuePrev.gtfsRt }} / {{ reportRow.valuePrev.gtfsStatic }}</div>
+                    <div class="ms-auto"><span class="badge rounded-pill" [ngClass]="reportRow.valuePrev.coverageClass">{{ reportRow.valuePrev.coverage }}%</span></div>
                   </div>
+                  <div class="progress" style="height: 6px;">
+                    <div class="progress-bar progress-light" [style.width.%]="reportRow.valuePrev.coverage"></div>
+                  </div>  
                 </td>
-                <td>{{ reportRow.valuePrev.coverage }}%</td>
+                
                 <td class="left-thick">{{ reportRow.valueNow.gtfsRt - reportRow.valuePrev.gtfsRt }}</td>
               </tr>
             </ng-container>

--- a/apps/gtfs-rt-static-report/src/app/detail-agency.component.html
+++ b/apps/gtfs-rt-static-report/src/app/detail-agency.component.html
@@ -8,26 +8,50 @@
       <div><a [routerLink]="'/home'">← MonthlyReport</a></div>
     </div>
 
+    <hr />
+
     <div class="d-flex overflow-auto mb-1">
       <div class="flex-grow-1 overflow-auto d-flex">
-        <table class="table table-hover table-bordered table-striped sticky-report" style="width: 800px;">
+        <table class="table table-hover table-bordered table-striped sticky-report">
           <thead>
-            <tr class="align-middle">
-              <th class="col">agency id</th>
-              <th scope="col col-sortable" (click)="onSortClick('name')">agency name</th>
-              <th scope="col col-sortable" (click)="onSortClick('keyA')">{{ this.model.keyA }}</th>
-              <th scope="col col-sortable" (click)="onSortClick('keyB')">{{ this.model.prevKeyB }}</th>
-              <th scope="col col-sortable" (click)="onSortClick('diff')">diff</th>
+            <tr class="align-middle bottom-thick">
+              <th class="col" style="max-width: 200px;">id</th>
+              <th class="left-thick" scope="col col-sortable" (click)="onSortClick('name')">agency name</th>
+              <th class="left-thick" scope="col col-sortable" (click)="onSortClick('keyA')" style="width: 200px">{{ this.model.keyA }} <br/> GTFS-RT / -static</th>
+              <th scope="col">Coverage</th>
+              <th scope="col" style="width: 200px" class="left-thick">
+                <select 
+                  class="form-select form-control form-control-sm" 
+                  [(ngModel)]="this.model.prevKeyB" 
+                  (ngModelChange)="onCompareValueChange()">
+                  <option *ngFor="let compareKey of this.model.compareKeys" [ngValue]="compareKey">{{ compareKey }}</option>
+                </select>
+                GTFS-RT / -static
+              </th>
+              <th scope="col">Coverage</th>
+              <th class="left-thick" scope="col col-sortable" (click)="onSortClick('diff')">diff</th>
             </tr>
           </thead>
           <tbody>
             <ng-container *ngFor="let reportRow of this.model.reportRows">
               <tr>
                 <td>{{ reportRow.agency.agency_id }}</td>
-                <td>{{ reportRow.agency.agency_name }}</td>
-                <td>{{ reportRow.valueNow }}</td>
-                <td>{{ reportRow.valuePrev }}</td>
-                <td>{{ reportRow.valueNow - reportRow.valuePrev }}</td>
+                <td class="left-thick">{{ reportRow.agency.agency_name }}</td>
+                <td class="left-thick">
+                  <div class="mb-1">{{ reportRow.valueNow.gtfsRt }} / {{ reportRow.valueNow.gtfsStatic }}</div>
+                  <div class="progress" style="height: 6px;">
+                    <div class="progress-bar progress-light" [style.width.%]="reportRow.valueNow.coverage"></div>
+                  </div>
+                </td>
+                <td class="align-middle">{{ reportRow.valueNow.coverage }}%</td>
+                <td class="left-thick">
+                  <div class="mb-1">{{ reportRow.valuePrev.gtfsRt }} / {{ reportRow.valuePrev.gtfsStatic }}</div>
+                  <div class="progress" style="height: 6px;">
+                    <div class="progress-bar progress-light" [style.width.%]="reportRow.valueNow.coverage"></div>
+                  </div>
+                </td>
+                <td>{{ reportRow.valuePrev.coverage }}%</td>
+                <td class="left-thick">{{ reportRow.valueNow.gtfsRt - reportRow.valuePrev.gtfsRt }}</td>
               </tr>
             </ng-container>
           </tbody>

--- a/apps/gtfs-rt-static-report/src/app/detail-agency.component.scss
+++ b/apps/gtfs-rt-static-report/src/app/detail-agency.component.scss
@@ -23,3 +23,16 @@ h1 {
 .col-sortable {
     cursor: pointer;
 }
+
+.left-thick {
+    border-left: 2px solid #b4b4b4;
+}
+
+tr.bottom-thick th {
+    border-bottom: 2px solid #b4b4b4;
+}
+
+.progress-light {
+  background-color: #cacaca;
+}
+

--- a/apps/gtfs-rt-static-report/src/app/detail-agency.component.scss
+++ b/apps/gtfs-rt-static-report/src/app/detail-agency.component.scss
@@ -35,4 +35,3 @@ tr.bottom-thick th {
 .progress-light {
   background-color: #cacaca;
 }
-

--- a/apps/gtfs-rt-static-report/src/app/detail-agency.component.ts
+++ b/apps/gtfs-rt-static-report/src/app/detail-agency.component.ts
@@ -35,13 +35,6 @@ interface PageModel {
   reportMetadata: GTFS_RT_Static_Report_Metadata_JSON | null,
 };
 
-interface RouteGTFS_Data {
-  routeId: string,
-  route: RouteJSON,
-  agency: AgencyJSON,
-};
-type MapFeedVersionGTFS_Data = Record<string, RouteGTFS_Data>;
-
 // 2026-03-09-1200
 type HrReportKey = string;
 

--- a/apps/gtfs-rt-static-report/src/app/detail-agency.component.ts
+++ b/apps/gtfs-rt-static-report/src/app/detail-agency.component.ts
@@ -6,9 +6,8 @@ import { FilenameDateRegexp, ReportHelpers } from './helpers/report-helpers';
 
 import { DataService } from './data.service';
 
-import { AgencyJSON, RouteJSON } from './models/gtfs/gtfs';
-import { Response_GTFS_RT } from './models/gtfs-rt/gtfs-rt-response';
-import { GTFS_RT_Static_Monthly_Report_JSON, GTFS_RT_Static_Report_Metadata_JSON } from './types/_all';
+import { AgencyJSON } from './models/gtfs/gtfs';
+import { GTFS_RT_Static_Monthly_Report_JSON, GTFS_RT_Static_Report, GTFS_RT_Static_Report_Metadata_JSON } from './types/_all';
 
 interface DetailReportRow {
   agency: AgencyJSON,
@@ -56,12 +55,12 @@ type MapDaysData = Record<HrReportKey, Record<string, MapAgencyReportData>>;
   styleUrls: ['./detail-agency.component.scss']
 })
 export class DetailAgencyComponent implements OnInit {
-  private mapGTFS_RouteAgency: Record<string, MapFeedVersionGTFS_Data>;
+  private mapGTFS_Agency: Record<string, Record<string, AgencyJSON>>;
   private mapDaysData: MapDaysData;
   public model: PageModel;
 
   constructor(private route: ActivatedRoute, private dataService: DataService) {
-   this.mapGTFS_RouteAgency = {};
+   this.mapGTFS_Agency = {};
    this.mapDaysData = {};
    this.model = {
     reportRows: [],
@@ -121,7 +120,7 @@ export class DetailAgencyComponent implements OnInit {
       return;
     }
 
-    this.mapGTFS_RouteAgency = {};
+    this.mapGTFS_Agency = {};
     this.mapDaysData = {};
 
     const reportYearF = timeMatches[1];
@@ -133,34 +132,29 @@ export class DetailAgencyComponent implements OnInit {
     const monthlyReport = await this.dataService.getMonthlyReport(ym);
     this.updateSelectedReportCell(monthlyReport, reportDayF, reportHrMinF);
 
-    const gtfsRT_SnapshotURL = ReportHelpers.computeGTFS_RT_URL(reportKey);
-    const gtfsRT = await this.dataService.fetchGTFS_RT_Snapshot(gtfsRT_SnapshotURL);
+    const reportURL = ReportHelpers.computeReportURLForTime(reportKey);
+    const reportData = await this.dataService.fetchGTFS_RT_StaticReport(reportURL);
+    await this.parseReport(reportData, reportKey);
 
-    await this.loadGTFS_Data(gtfsRT.header.feedVersion);
-    this.parseGTFS_RT(gtfsRT, reportKey);
-
-    const mapCompareSnapshotURLs: Record<string, string> = {};
+    const mapCompareReportURLs: Record<string, string> = {};
     const mapDayCompareReports = monthlyReport.compare_days[reportDayF] ?? null;
-
     if (mapDayCompareReports) {
       const snapshotCompareData = mapDayCompareReports[reportHrMinF] ?? null;
       if (snapshotCompareData) {
         const dayKeys = Object.keys(snapshotCompareData.map_days);
         dayKeys.forEach(dayKey => {
-          // https://tools.opentransportdata.swiss/gtfs-rt-snapshot/2026/03/11/GTFS_RT-2026-03-11-1100.json
           const compareReportKey = dayKey + '-' + reportHrMinF;
-          const compareDaySnapshotURL = ReportHelpers.computeGTFS_RT_URL(compareReportKey);
-          mapCompareSnapshotURLs[compareReportKey] = compareDaySnapshotURL;
+          const compareReportURL = ReportHelpers.computeReportURLForTime(compareReportKey);
+          mapCompareReportURLs[compareReportKey] = compareReportURL;
         });
       }
     }
 
-    const compareReportKeys = Object.keys(mapCompareSnapshotURLs);
+    const compareReportKeys = Object.keys(mapCompareReportURLs);
     for (const compareReportKey of compareReportKeys) {
-      const compareDaySnapshotURL = mapCompareSnapshotURLs[compareReportKey];
-      const compareGtfsRT_Snapshot = await this.dataService.fetchGTFS_RT_Snapshot(compareDaySnapshotURL);
-      await this.loadGTFS_Data(compareGtfsRT_Snapshot.header.feedVersion);
-      this.parseGTFS_RT(compareGtfsRT_Snapshot, compareReportKey);
+      const compareDayReportURL = mapCompareReportURLs[compareReportKey];
+      const compareReportData = await this.dataService.fetchGTFS_RT_StaticReport(compareDayReportURL);
+      await this.parseReport(compareReportData, compareReportKey);
     }
 
     const mapAgencies: Record<string, AgencyJSON> = {};
@@ -225,155 +219,46 @@ export class DetailAgencyComponent implements OnInit {
     });
   }
 
-  private async loadGTFS_Data(feedVersion: string) {
-    if (feedVersion in this.mapGTFS_RouteAgency) {
-      // poor's man cache - return if already computed
+  private async loadGTFS_DataForGTFS_Day(gtfsDay: string) {
+    if (gtfsDay in this.mapGTFS_Agency) {
       return;
     }
 
-    this.mapGTFS_RouteAgency[feedVersion] = {};
-
-    const gtfsDay = ReportHelpers.parseGTFS_feedVersionAsGTFS_Day(feedVersion);
-
+    this.mapGTFS_Agency[gtfsDay] = {};
+  
     const gtfsAgencyData = await this.dataService.fetchGTFS_Agency(gtfsDay);
-    const gtfsRoutesData = await this.dataService.fetchGTFS_Routes(gtfsDay);
-
     const mapAgency: Record<string, AgencyJSON> = {};
     gtfsAgencyData.rows.forEach(row => {
       mapAgency[row.agency_id] = row;
     });
 
-    gtfsRoutesData.rows.forEach(row => {
-      const routeId = row.route_id;
-      const agency = mapAgency[row.agency_id] ?? null;
-      if (agency === null) {
-        throw new Error('Cant find agency: ' + row.agency_id);
-      }
-
-      const routeGTFS_Data: RouteGTFS_Data = {
-        routeId: routeId,
-        agency: agency,
-        route: row,
-      };
-
-      this.mapGTFS_RouteAgency[feedVersion][routeId] = routeGTFS_Data;
-    });
+    this.mapGTFS_Agency[gtfsDay] = mapAgency;
   }
 
-  private parseGTFS_RT(gtfsRT: Response_GTFS_RT, reportKey: string) {
-    const mapGTFS_Routes = this.mapGTFS_RouteAgency[gtfsRT.header.feedVersion] ?? null;
-    if (mapGTFS_Routes === null) {
-      throw new Error('No lookups for feedVersion: ' + gtfsRT.header.feedVersion);
+  private async parseReport(reportData: GTFS_RT_Static_Report, reportKey: string) {
+    const gtfsDay = reportData.gtfs_trips_active_data.gtfs_day;
+    
+    await this.loadGTFS_DataForGTFS_Day(gtfsDay);
+    const mapGTFS_Agency = this.mapGTFS_Agency[gtfsDay] ?? null;
+    if (mapGTFS_Agency === null) {
+      throw new Error('No lookups for GTFS day: ' + gtfsDay);
     }
 
     this.mapDaysData[reportKey] = {};
 
-    const gtfsRT_Date = new Date(gtfsRT.header.timestamp * 1000);
-
-    gtfsRT.entity.forEach(entity => {
-      const routeId = entity.tripUpdate?.trip?.routeId ?? null;
-      if (routeId === null) {
-        console.log('ERROR: - entity with null routeId');
-        console.log(entity);
-        return;
+    const agencyIds = Object.keys(reportData.gtfs_rt_active_by_agency);
+    agencyIds.forEach(agencyId => {
+      const agencyJSON = mapGTFS_Agency[agencyId] ?? null;
+      if (agencyJSON === null) {
+        throw new Error('No GTFS agenct for ' + agencyId + ' in GTFS day: ' + gtfsDay);
       }
 
-      const startDateS = entity.tripUpdate?.trip?.startDate ?? null;
-      const startTimeS = entity.tripUpdate?.trip?.startTime ?? null;
-      if ((startDateS === null) || (startTimeS === null)) {
-        console.log('ERROR: - entity with null startDate/startTime');
-        console.log(entity);
-        return;
-      }
-
-      let tripStartDate: Date | null = null;
-
-      try {
-        const startDateF = startDateS.substring(0, 4) + '-' + startDateS.substring(4, 6) + '-' + startDateS.substring(6, 8);
-        const tripStartDateF = startDateF + ' ' + startTimeS;
-        tripStartDate = new Date(tripStartDateF);
-      } catch (error) {
-        console.log('ERROR: - cant parse trip startDate/startTime');
-        console.log(entity);
-        console.log(error);
-        return;
-      }
-
-      if (tripStartDate === null) {
-        console.log('ERROR: - cant parse trip startDate/startTime');
-        console.log(entity);
-        return;
-      }
-
-      if (tripStartDate > gtfsRT_Date) {
-        return;
-      }
-
-      const routeGTFS_Data = mapGTFS_Routes[routeId] ?? null;
-
-      const agencyId: string = (() => {
-        if (routeId.startsWith('ojp:')) {
-          return 'ojp';
-        }
-
-        if (routeId.startsWith('atv:')) {
-          return 'atv';
-        }
-        
-        if (routeGTFS_Data === null) {
-          // console.log('ERROR: cant find route/agency for item');
-          // console.log(entity);
-          return 'NO_AGENCY';
-        }
-
-        return routeGTFS_Data.agency.agency_id;
-      })();
-
-      if (!(agencyId in this.mapDaysData[reportKey])) {
-        const agencyJSON: AgencyJSON = (() => {
-          if (routeGTFS_Data) {
-            return routeGTFS_Data.agency;
-          }
-
-          const fakeAgency: AgencyJSON = {
-            agency_id: agencyId,
-            agency_name: '',
-            agency_url: '',
-            agency_phone: '',
-            agency_timezone: '',
-            agency_lang: '',
-          };
-
-          return fakeAgency;
-        })();
-
-        this.mapDaysData[reportKey][agencyId] = {
-          id: agencyId,
-          agencyJSON: agencyJSON,
-          activeItemsTotal: 0,
-          byRouteShortName: {},
-        };
-        
-        if (routeGTFS_Data) {
-          this.mapDaysData[reportKey][agencyId].agencyJSON = routeGTFS_Data.agency;
-        }
-      }
-
-      this.mapDaysData[reportKey][agencyId].activeItemsTotal += 1;
-
-      const routeShortName: string = (() => {
-        if (routeGTFS_Data === null) {
-          return 'NO_ROUTE';
-        }
-
-        const routeShortName = routeGTFS_Data.route.route_short_name;
-
-        return routeShortName;
-      })();
-      if (!(routeShortName in this.mapDaysData[reportKey][agencyId].byRouteShortName)) {
-        this.mapDaysData[reportKey][agencyId].byRouteShortName[routeShortName] = 0;
-      }
-      this.mapDaysData[reportKey][agencyId].byRouteShortName[routeShortName] += 1;
+      const gtfsRT_activeNo = reportData.gtfs_rt_active_by_agency[agencyId];
+      this.mapDaysData[reportKey][agencyId] = {
+        id: agencyId,
+        agencyJSON: agencyJSON,
+        activeItemsTotal: gtfsRT_activeNo,
+      };
     });
   }
 

--- a/apps/gtfs-rt-static-report/src/app/detail-agency.component.ts
+++ b/apps/gtfs-rt-static-report/src/app/detail-agency.component.ts
@@ -14,10 +14,12 @@ interface DetailReportRow {
   valueNow: {
     gtfsRt: number,
     gtfsStatic: number,
+    coverage: number,
   },
   valuePrev: {
     gtfsRt: number,
     gtfsStatic: number,
+    coverage: number,
   },
 };
 
@@ -198,12 +200,22 @@ export class DetailAgencyComponent implements OnInit {
         valueNow: {
           gtfsRt: this.computeAgencySnapshotData(agencyJSON, this.model.keyA, 'gtfs_rt'),
           gtfsStatic: this.computeAgencySnapshotData(agencyJSON, this.model.keyA, 'gtfs_static'),
+          coverage: 0,
         },
         valuePrev: {
           gtfsRt: this.computeAgencySnapshotData(agencyJSON, this.model.prevKeyB, 'gtfs_rt'),
           gtfsStatic: this.computeAgencySnapshotData(agencyJSON, this.model.prevKeyB, 'gtfs_static'),
+          coverage: 0,
         },
       };
+
+      if (reportRow.valueNow.gtfsStatic !== 0) {
+        reportRow.valueNow.coverage = Math.round(reportRow.valueNow.gtfsRt / reportRow.valueNow.gtfsStatic * 100);
+      }
+
+      if (reportRow.valuePrev.gtfsStatic !== 0) {
+        reportRow.valuePrev.coverage = Math.round(reportRow.valuePrev.gtfsRt / reportRow.valuePrev.gtfsStatic * 100);
+      }
 
       this.model.reportRows.push(reportRow);
     });

--- a/apps/gtfs-rt-static-report/src/app/detail-agency.component.ts
+++ b/apps/gtfs-rt-static-report/src/app/detail-agency.component.ts
@@ -11,8 +11,12 @@ import { GTFS_RT_Static_Monthly_Report_JSON, GTFS_RT_Static_Report, GTFS_RT_Stat
 
 interface DetailReportRow {
   agency: AgencyJSON,
-  valueNow: number,
-  valuePrev: number,
+  valueNow: {
+    gtfsRt: number,
+  },
+  valuePrev: {
+    gtfsRt: number,
+  },
 };
 
 type SortColumn = 'name' | 'keyA' | 'keyB' | 'diff';
@@ -44,8 +48,8 @@ type HrReportKey = string;
 interface MapAgencyReportData {
   id: string,
   agencyJSON: AgencyJSON,
-  activeItemsTotal: number,
-  byRouteShortName: Record<string, number>,
+  gtfsRtActiveNo: number,
+  gtfsStaticActiveNo: number,
 };
 type MapDaysData = Record<HrReportKey, Record<string, MapAgencyReportData>>;
 
@@ -190,8 +194,12 @@ export class DetailAgencyComponent implements OnInit {
     this.model.agencyRows.forEach(agencyJSON => {
       const reportRow: DetailReportRow = {
         agency: agencyJSON,
-        valueNow: this.computeAgencySnapshotData(agencyJSON, this.model.keyA),
-        valuePrev: this.computeAgencySnapshotData(agencyJSON, this.model.prevKeyB),
+        valueNow: {
+          gtfsRt: this.computeAgencySnapshotData(agencyJSON, this.model.keyA, 'gtfs_rt'),
+        },
+        valuePrev: {
+          gtfsRt: this.computeAgencySnapshotData(agencyJSON, this.model.prevKeyB, 'gtfs_rt'),
+        },
       };
 
       this.model.reportRows.push(reportRow);
@@ -199,16 +207,16 @@ export class DetailAgencyComponent implements OnInit {
     this.model.reportRows.sort((a, b) => {
       let expr = (() => {
         if (this.model.sort.column === 'keyA') {
-          return a.valueNow - b.valuePrev;
+          return a.valueNow.gtfsRt - b.valuePrev.gtfsRt;
         }
         if (this.model.sort.column === 'keyB') {
-          return a.valuePrev - b.valuePrev;
+          return a.valuePrev.gtfsRt - b.valuePrev.gtfsRt;
         }
         if (this.model.sort.column === 'name') {
           return a.agency.agency_name.localeCompare(b.agency.agency_name);
         }
 
-        return (a.valueNow - a.valuePrev) - (b.valueNow - b.valuePrev);
+        return (a.valueNow.gtfsRt - a.valuePrev.gtfsRt) - (b.valueNow.gtfsRt - b.valuePrev.gtfsRt);
       })();
       
       if (this.model.sort.direction === 'desc') {
@@ -246,18 +254,18 @@ export class DetailAgencyComponent implements OnInit {
 
     this.mapDaysData[reportKey] = {};
 
-    const agencyIds = Object.keys(reportData.gtfs_rt_active_by_agency);
+    const agencyIds = Object.keys(reportData.gtfs_trips_active_data.trips_active_by_agency);
     agencyIds.forEach(agencyId => {
       const agencyJSON = mapGTFS_Agency[agencyId] ?? null;
       if (agencyJSON === null) {
         throw new Error('No GTFS agenct for ' + agencyId + ' in GTFS day: ' + gtfsDay);
       }
 
-      const gtfsRT_activeNo = reportData.gtfs_rt_active_by_agency[agencyId];
+      const gtfsRT_activeNo = reportData.gtfs_rt_active_by_agency[agencyId] ?? 0;
       this.mapDaysData[reportKey][agencyId] = {
         id: agencyId,
         agencyJSON: agencyJSON,
-        activeItemsTotal: gtfsRT_activeNo,
+        gtfsRtActiveNo: gtfsRT_activeNo,
       };
     });
   }

--- a/apps/gtfs-rt-static-report/src/app/detail-agency.component.ts
+++ b/apps/gtfs-rt-static-report/src/app/detail-agency.component.ts
@@ -15,11 +15,13 @@ interface DetailReportRow {
     gtfsRt: number,
     gtfsStatic: number,
     coverage: number,
+    coverageClass: string,
   },
   valuePrev: {
     gtfsRt: number,
     gtfsStatic: number,
     coverage: number,
+    coverageClass: string,
   },
 };
 
@@ -219,11 +221,13 @@ export class DetailAgencyComponent implements OnInit {
           gtfsRt: this.computeAgencySnapshotData(agencyJSON, this.model.keyA, 'gtfs_rt'),
           gtfsStatic: this.computeAgencySnapshotData(agencyJSON, this.model.keyA, 'gtfs_static'),
           coverage: 0,
+          coverageClass: '',
         },
         valuePrev: {
           gtfsRt: this.computeAgencySnapshotData(agencyJSON, this.model.prevKeyB, 'gtfs_rt'),
           gtfsStatic: this.computeAgencySnapshotData(agencyJSON, this.model.prevKeyB, 'gtfs_static'),
           coverage: 0,
+          coverageClass: '',
         },
       };
 
@@ -234,6 +238,9 @@ export class DetailAgencyComponent implements OnInit {
       if (reportRow.valuePrev.gtfsStatic !== 0) {
         reportRow.valuePrev.coverage = Math.round(reportRow.valuePrev.gtfsRt / reportRow.valuePrev.gtfsStatic * 100);
       }
+
+      reportRow.valueNow.coverageClass = this.computeCoverageClassName(reportRow.valueNow.gtfsRt, reportRow.valueNow.coverage);
+      reportRow.valuePrev.coverageClass = this.computeCoverageClassName(reportRow.valuePrev.gtfsRt, reportRow.valuePrev.coverage);
 
       this.model.reportRows.push(reportRow);
     });

--- a/apps/gtfs-rt-static-report/src/app/detail-agency.component.ts
+++ b/apps/gtfs-rt-static-report/src/app/detail-agency.component.ts
@@ -192,6 +192,24 @@ export class DetailAgencyComponent implements OnInit {
     }
   }
 
+  private computeCoverageClassName(value: number, coverage: number) {
+    if (value <= 10) {
+      return 'text-black';
+    } else {
+      if (coverage > 95) {
+        return 'text-bg-success';
+      }
+      if (coverage > 80) {
+        return 'text-bg-warning';
+      }
+      if (coverage > 50) {
+        return 'text-bg-secondary';
+      }
+
+      return 'text-bg-danger';
+    }
+  }
+
   private updatePageModel() {
     this.model.reportRows = [];
     this.model.agencyRows.forEach(agencyJSON => {

--- a/apps/gtfs-rt-static-report/src/app/detail-agency.component.ts
+++ b/apps/gtfs-rt-static-report/src/app/detail-agency.component.ts
@@ -13,9 +13,11 @@ interface DetailReportRow {
   agency: AgencyJSON,
   valueNow: {
     gtfsRt: number,
+    gtfsStatic: number,
   },
   valuePrev: {
     gtfsRt: number,
+    gtfsStatic: number,
   },
 };
 
@@ -170,16 +172,22 @@ export class DetailAgencyComponent implements OnInit {
     this.updatePageModel();
   }
 
-  private computeAgencySnapshotData(agency: AgencyJSON, key: string): number {
-    const dataKey = this.mapDaysData[key] ?? null;
+  private computeAgencySnapshotData(agency: AgencyJSON, reportKey: string, property: 'gtfs_rt' | 'gtfs_static'): number {
+    const dataKey = this.mapDaysData[reportKey] ?? null;
     if (dataKey === null) {
-      return 0;
+      return -1;
     }
 
     const agencySnapshotData = dataKey[agency.agency_id] ?? null;
-    const value = agencySnapshotData === null ? 0 : agencySnapshotData.activeItemsTotal;
+    if (agencySnapshotData === null) {
+      return 0;
+    }
 
-    return value;
+    if (property ===  'gtfs_rt') {
+      return agencySnapshotData.gtfsRtActiveNo;
+    } else {
+      return agencySnapshotData.gtfsStaticActiveNo;
+    }
   }
 
   private updatePageModel() {
@@ -189,9 +197,11 @@ export class DetailAgencyComponent implements OnInit {
         agency: agencyJSON,
         valueNow: {
           gtfsRt: this.computeAgencySnapshotData(agencyJSON, this.model.keyA, 'gtfs_rt'),
+          gtfsStatic: this.computeAgencySnapshotData(agencyJSON, this.model.keyA, 'gtfs_static'),
         },
         valuePrev: {
           gtfsRt: this.computeAgencySnapshotData(agencyJSON, this.model.prevKeyB, 'gtfs_rt'),
+          gtfsStatic: this.computeAgencySnapshotData(agencyJSON, this.model.prevKeyB, 'gtfs_static'),
         },
       };
 
@@ -255,9 +265,11 @@ export class DetailAgencyComponent implements OnInit {
       }
 
       const gtfsRT_activeNo = reportData.gtfs_rt_active_by_agency[agencyId] ?? 0;
+      const gtfsStatc_activeNo = reportData.gtfs_trips_active_data.trips_active_by_agency[agencyId] ?? 0;
       this.mapDaysData[reportKey][agencyId] = {
         id: agencyId,
         agencyJSON: agencyJSON,
+        gtfsStaticActiveNo: gtfsStatc_activeNo,
         gtfsRtActiveNo: gtfsRT_activeNo,
       };
     });

--- a/apps/gtfs-rt-static-report/src/app/detail-agency.component.ts
+++ b/apps/gtfs-rt-static-report/src/app/detail-agency.component.ts
@@ -23,9 +23,13 @@ interface DetailReportRow {
     coverage: number,
     coverageClass: string,
   },
+  computed: {
+    rtDiff: number,
+    deltaDiff: number,
+  }
 };
 
-type SortColumn = 'name' | 'keyA' | 'keyB' | 'diff';
+type SortColumn = 'name' | 'keyA' | 'keyB' | 'rt-diff' | 'delta-diff';
 type SortDirection = 'asc' | 'desc';
 
 interface PageModel {
@@ -72,7 +76,7 @@ export class DetailAgencyComponent implements OnInit {
       agencyRows: [],
       compareKeys: ['... loading'],
       sort: {
-        column: 'diff',
+        column: 'rt-diff',
         direction: 'asc',
       },
       reportMetadata: null,
@@ -174,6 +178,7 @@ export class DetailAgencyComponent implements OnInit {
     this.model.prevKeyB = this.model.compareKeys.length > 0 ? this.model.compareKeys[0] : 'n/a';
 
     this.updatePageModel();
+    this.sortRows();
   }
 
   private computeAgencySnapshotData(agency: AgencyJSON, reportKey: string, property: 'gtfs_rt' | 'gtfs_static'): number {
@@ -196,7 +201,7 @@ export class DetailAgencyComponent implements OnInit {
 
   private computeCoverageClassName(value: number, coverage: number) {
     if (value <= 10) {
-      return 'text-black';
+      return 'text-black progress-light';
     } else {
       if (coverage > 95) {
         return 'text-bg-success';
@@ -213,23 +218,34 @@ export class DetailAgencyComponent implements OnInit {
   }
 
   private updatePageModel() {
-    this.model.reportRows = [];
     this.model.agencyRows.forEach(agencyJSON => {
-      const reportRow: DetailReportRow = {
-        agency: agencyJSON,
-        valueNow: {
-          gtfsRt: this.computeAgencySnapshotData(agencyJSON, this.model.keyA, 'gtfs_rt'),
-          gtfsStatic: this.computeAgencySnapshotData(agencyJSON, this.model.keyA, 'gtfs_static'),
-          coverage: 0,
-          coverageClass: '',
-        },
-        valuePrev: {
-          gtfsRt: this.computeAgencySnapshotData(agencyJSON, this.model.prevKeyB, 'gtfs_rt'),
-          gtfsStatic: this.computeAgencySnapshotData(agencyJSON, this.model.prevKeyB, 'gtfs_static'),
-          coverage: 0,
-          coverageClass: '',
-        },
-      };
+      let reportRow = this.model.reportRows.find(el => el.agency.agency_id === agencyJSON.agency_id) ?? null;
+      if (reportRow === null) {
+        reportRow = {
+          agency: agencyJSON,
+          valueNow: {
+            gtfsRt: this.computeAgencySnapshotData(agencyJSON, this.model.keyA, 'gtfs_rt'),
+            gtfsStatic: this.computeAgencySnapshotData(agencyJSON, this.model.keyA, 'gtfs_static'),
+            coverage: 0,
+            coverageClass: '',
+          },
+          valuePrev: {
+            // gtfsRt, gtfsStatic - are updated whenever new data is pulled
+            gtfsRt: -1,
+            gtfsStatic: -1,
+            coverage: 0,
+            coverageClass: '',
+          },
+          computed: {
+            rtDiff: -1,
+            deltaDiff: -1,
+          },
+        };
+        this.model.reportRows.push(reportRow);
+      }
+
+      reportRow.valuePrev.gtfsRt = this.computeAgencySnapshotData(agencyJSON, this.model.prevKeyB, 'gtfs_rt');
+      reportRow.valuePrev.gtfsStatic = this.computeAgencySnapshotData(agencyJSON, this.model.prevKeyB, 'gtfs_static');
 
       if (reportRow.valueNow.gtfsStatic !== 0) {
         reportRow.valueNow.coverage = Math.round(reportRow.valueNow.gtfsRt / reportRow.valueNow.gtfsStatic * 100);
@@ -242,8 +258,12 @@ export class DetailAgencyComponent implements OnInit {
       reportRow.valueNow.coverageClass = this.computeCoverageClassName(reportRow.valueNow.gtfsRt, reportRow.valueNow.coverage);
       reportRow.valuePrev.coverageClass = this.computeCoverageClassName(reportRow.valuePrev.gtfsRt, reportRow.valuePrev.coverage);
 
-      this.model.reportRows.push(reportRow);
+      reportRow.computed.rtDiff = reportRow.valueNow.gtfsRt - reportRow.valuePrev.gtfsRt;
+      reportRow.computed.deltaDiff = Math.abs((reportRow.valueNow.gtfsStatic - reportRow.valueNow.gtfsRt) - (reportRow.valuePrev.gtfsStatic - reportRow.valuePrev.gtfsRt));
     });
+  }
+  
+  private sortRows() {
     this.model.reportRows.sort((a, b) => {
       let expr = (() => {
         if (this.model.sort.column === 'keyA') {
@@ -252,11 +272,15 @@ export class DetailAgencyComponent implements OnInit {
         if (this.model.sort.column === 'keyB') {
           return a.valuePrev.gtfsRt - b.valuePrev.gtfsRt;
         }
-        if (this.model.sort.column === 'name') {
-          return a.agency.agency_name.localeCompare(b.agency.agency_name);
+        if (this.model.sort.column === 'rt-diff') {
+          return a.computed.rtDiff - b.computed.rtDiff;
+        }
+        if (this.model.sort.column === 'delta-diff') {
+          return a.computed.deltaDiff - b.computed.deltaDiff;
         }
 
-        return (a.valueNow.gtfsRt - a.valuePrev.gtfsRt) - (b.valueNow.gtfsRt - b.valuePrev.gtfsRt);
+        // default name sorting
+        return a.agency.agency_name.localeCompare(b.agency.agency_name);
       })();
       
       if (this.model.sort.direction === 'desc') {
@@ -320,8 +344,8 @@ export class DetailAgencyComponent implements OnInit {
     if (this.model.sort.column === column) {
       this.model.sort.direction = this.model.sort.direction === 'asc' ? 'desc' : 'asc';
     } else {
-      const sortAscColumns: SortColumn[] = ['name', 'diff'];
-      if (sortAscColumns.includes(column)) {
+      const sortAscendingColumns: SortColumn[] = ['name', 'rt-diff'];
+      if (sortAscendingColumns.includes(column)) {
         this.model.sort.direction = 'asc';
       } else {
         this.model.sort.direction = 'desc';
@@ -331,5 +355,6 @@ export class DetailAgencyComponent implements OnInit {
     }
 
     this.updatePageModel();
+    this.sortRows();
   }
 }

--- a/apps/gtfs-rt-static-report/src/app/detail-agency.component.ts
+++ b/apps/gtfs-rt-static-report/src/app/detail-agency.component.ts
@@ -60,20 +60,20 @@ export class DetailAgencyComponent implements OnInit {
   public model: PageModel;
 
   constructor(private route: ActivatedRoute, private dataService: DataService) {
-   this.mapGTFS_Agency = {};
-   this.mapDaysData = {};
-   this.model = {
-    reportRows: [],
-    keyA: 'n/a',
-    prevKeyB: '... loading',
-    agencyRows: [],
-    compareKeys: ['... loading'],
-    sort: {
-      column: 'diff',
-      direction: 'asc',
-    },
-    reportMetadata: null,
-   };
+    this.mapGTFS_Agency = {};
+    this.mapDaysData = {};
+    this.model = {
+      reportRows: [],
+      keyA: 'n/a',
+      prevKeyB: '... loading',
+      agencyRows: [],
+      compareKeys: ['... loading'],
+      sort: {
+        column: 'diff',
+        direction: 'asc',
+      },
+      reportMetadata: null,
+    };
   }
 
   async ngOnInit(): Promise<void> {

--- a/apps/gtfs-rt-static-report/src/app/detail-agency.component.ts
+++ b/apps/gtfs-rt-static-report/src/app/detail-agency.component.ts
@@ -261,7 +261,7 @@ export class DetailAgencyComponent implements OnInit {
     agencyIds.forEach(agencyId => {
       const agencyJSON = mapGTFS_Agency[agencyId] ?? null;
       if (agencyJSON === null) {
-        throw new Error('No GTFS agenct for ' + agencyId + ' in GTFS day: ' + gtfsDay);
+        throw new Error('No GTFS agency for ' + agencyId + ' in GTFS day: ' + gtfsDay);
       }
 
       const gtfsRT_activeNo = reportData.gtfs_rt_active_by_agency[agencyId] ?? 0;

--- a/apps/gtfs-rt-static-report/src/app/helpers/report-helpers.ts
+++ b/apps/gtfs-rt-static-report/src/app/helpers/report-helpers.ts
@@ -37,6 +37,23 @@ export class ReportHelpers {
     return date;
   }
 
+  // https://tools.opentransportdata.swiss/gtfs-rt-static-compare-report/2026/06/27/gtfs_rt_static_report-2026-06-27-1800.json
+  public static computeReportURLForTime(reportTime: string) {
+    const reportTimeParts = reportTime.split('-');
+    const reportYearF = reportTimeParts[0];
+    const reportMonthF = reportTimeParts[1];
+    const reportDayF = reportTimeParts[2];
+    const reportHrMinF = reportTimeParts[3];
+
+    let templateURL = 'https://tools.opentransportdata.swiss/gtfs-rt-static-compare-report/[YYYY]/[MM]/[DD]/gtfs_rt_static_report-[YYYY]-[MM]-[DD]-[HHMM].json';
+    templateURL = templateURL.replaceAll('[YYYY]', reportYearF);
+    templateURL = templateURL.replaceAll('[MM]', reportMonthF);
+    templateURL = templateURL.replaceAll('[DD]', reportDayF);
+    templateURL = templateURL.replaceAll('[HHMM]', reportHrMinF);
+
+    return templateURL;
+  }
+
   public static computeGTFS_RT_URL(gtfs_rt_filename: string | null) {
     if (gtfs_rt_filename === null) {
       return '';

--- a/apps/gtfs-rt-static-report/src/app/types/_all.ts
+++ b/apps/gtfs-rt-static-report/src/app/types/_all.ts
@@ -19,6 +19,22 @@ export interface GTFS_RT_Static_Report_Metadata_JSON {
   tripNOK_NOJP_no: number
 }
 
+export interface GTFS_RT_Static_Report {
+  metadata: GTFS_RT_Static_Report_Metadata_JSON,
+  tripOK_routeNOK: string[],
+  tripNOK_routeOK: string[],
+  tripNOK_routeNOK: string[],
+
+  gtfs_rt_by_agency: Record<string, number>,
+  gtfs_rt_active_by_agency: Record<string, number>,
+
+  gtfs_trips_active_data: {
+    gtfs_day: string,
+    trips_active_no: number,
+    trips_active_by_agency: Record<string, number>,
+  }
+}
+
 interface GTFS_RT_Static_Report_Compare_JSON {
   compare_type: 'h' | 'w' | 'w_p'
   map_days: Record<string, number>

--- a/tools/_shared/inc/helpers/gtfs_helpers.py
+++ b/tools/_shared/inc/helpers/gtfs_helpers.py
@@ -81,15 +81,25 @@ def massage_datetime_to_hhmm(datetime_s: Optional[str]) -> str:
     return datetime_hhmm
 
 def compute_date_from_gtfs_db_filename(db_filename: str):
-    # gtfs_2021-03-10.sqlite
-    date_matches = re.match(r"^.+?_([0-9]{4}-[0-9]{2}-[0-9]{2})\.sqlite$", db_filename)
-
-    if not date_matches:
+    try:
+        gtfs_date = parse_gtfs_day(db_filename)
+        return gtfs_date
+    except Exception as e:
+        print(f"Error parsing {db_filename}: {e}")
         return None
 
-    gtfs_date = datetime.datetime.strptime(date_matches[1], '%Y-%m-%d').date()
-
-    return gtfs_date
+def parse_gtfs_day(day_s: str) -> datetime.date:
+    # strip '-' chars and try to match YYYYMMDD
+    day_s_f = day_s.replace('-', '')
+    day_regexp = r"([0-9]{4})([0-9]{2})([0-9]{2})"
+    day_matches = re.search(day_regexp, day_s_f)
+    if day_matches is None:
+        raise ValueError(f'expected gtfs_day in YYYYMMDD or YYYY-MM-DD format: got {day_s} instead')
+    
+    day_f = day_matches[1] + '-' + day_matches[2] + '-' + day_matches[3]
+    day = datetime.datetime.strptime(day_f, '%Y-%m-%d').date()
+    
+    return day
 
 def compute_gtfs_db_filename(gtfs_day: str):
     db_filename = f'gtfs_{gtfs_day}.sqlite'

--- a/tools/_shared/inc/models/gtfs_rt_static_report.py
+++ b/tools/_shared/inc/models/gtfs_rt_static_report.py
@@ -72,10 +72,14 @@ class GTFS_RT_Static_Report:
     tripOK_routeNOK: list[str]
     tripNOK_routeOK: list[str]
     tripNOK_routeNOK: list[str]
+
+    gtfs_rt_by_agency: dict[str, int]
+    gtfs_rt_active_by_agency: dict[str, int]
+    gtfs_trips_active_data: GTFS_TripsActiveData
     
     @staticmethod
-    def init_with_metadata(metdata: GTFS_RT_Static_Report_Metadata):
-        report = GTFS_RT_Static_Report(metdata, [], [], [])
+    def init_with_metadata(metdata: GTFS_RT_Static_Report_Metadata, gtfs_rt_by_agency: dict[str, int], gtfs_rt_active_by_agency: dict[str, int], gtfs_trips_active_data: GTFS_TripsActiveData):
+        report = GTFS_RT_Static_Report(metdata, [], [], [], gtfs_rt_by_agency=gtfs_rt_by_agency, gtfs_trips_active_data=gtfs_trips_active_data, gtfs_rt_active_by_agency=gtfs_rt_active_by_agency)
         return report
     
     @staticmethod

--- a/tools/_shared/inc/models/gtfs_rt_static_report.py
+++ b/tools/_shared/inc/models/gtfs_rt_static_report.py
@@ -16,6 +16,11 @@ class GTFS_RT_Static_Report_Compare_Info:
         compare_info = GTFS_RT_Static_Report_Compare_Info(**data_json)
         return compare_info
 
+class GTFS_TripsActiveData(TypedDict):
+    gtfs_day: str
+    trips_active_no: int
+    trips_active_by_agency: dict[str, int]
+
 @dataclass
 class GTFS_RT_Static_Report_Metadata:
     report_dt: datetime

--- a/tools/_shared/inc/models/gtfs_rt_static_report.py
+++ b/tools/_shared/inc/models/gtfs_rt_static_report.py
@@ -2,7 +2,7 @@ import os, sys
 
 from dataclasses import dataclass, asdict
 from datetime import datetime
-from typing import Any
+from typing import Any, TypedDict
 
 @dataclass
 class GTFS_RT_Static_Report_Compare_Info:

--- a/tools/gtfs-rt-static-compare/cli_batch_compare.py
+++ b/tools/gtfs-rt-static-compare/cli_batch_compare.py
@@ -116,7 +116,6 @@ def main():
             gtfs_controller.compare_gtfs_rt_from_file(
                 gtfs_rt_response, file_dt, gtfs_rt_file_path, 
                 gtfs_catalog_item, 
-                gtfs_db, 
                 day_data_trips,
             )
         # loop files

--- a/tools/gtfs-rt-static-compare/cli_batch_compare.py
+++ b/tools/gtfs-rt-static-compare/cli_batch_compare.py
@@ -4,11 +4,11 @@ import re
 import argparse
 
 from pathlib import Path
-from typing import Dict, List
+from typing import List
 from datetime import datetime
 
 from compare_gtfs_rt_static.gtfs_controller import GTFS_Controller
-from compare_gtfs_rt_static.gtfs_db import GTFS_DB
+from compare_gtfs_rt_static.gtfs_db import GTFS_DB, DayTripData
 from compare_gtfs_rt_static.helpers.json_helpers import load_json_from_file
 from compare_gtfs_rt_static.models.gtfs_rt import GTFS_RT_Response
 from compare_gtfs_rt_static.helpers.log_helpers import format_path, log_message
@@ -34,7 +34,7 @@ def main():
     log_message(f'filter (starts with)  : GTFS_RT-{report_date_filter}')
     print()
 
-    gtfs_rt_file_paths: List[Path] = []
+    map_gtfs_rt_file_paths: dict[str, List[Path]] = {}
     for gtfs_rt_file_path in gtfs_rt_snapshot_files_path.rglob('*.json*'):
         keep_file = False
         if gtfs_rt_file_path.name.startswith(f'GTFS_RT-{report_date_filter}'):
@@ -45,55 +45,86 @@ def main():
         file_matches = re.match(file_match_regexp, gtfs_rt_file_path.name)
         if file_matches is None:
             continue
+
+        file_day_f: str = file_matches[1]
+        if file_day_f not in map_gtfs_rt_file_paths:
+            map_gtfs_rt_file_paths[file_day_f] = []
         
-        gtfs_rt_file_paths.append(gtfs_rt_file_path)
+        map_gtfs_rt_file_paths[file_day_f].append(gtfs_rt_file_path)
     #
-    gtfs_rt_file_paths.sort()
+
+    sorted_days = sorted(map_gtfs_rt_file_paths.keys())
+    sorted_map_gtfs_rt_file_paths: dict[str, List[Path]] = {}
+    files_no = 0
+    for file_day_f in sorted_days:
+        gtfs_rt_file_paths = map_gtfs_rt_file_paths[file_day_f]
+        sorted_map_gtfs_rt_file_paths[file_day_f] = sorted(gtfs_rt_file_paths)
+        files_no += len(gtfs_rt_file_paths)
+    # end for days - sort
+    map_gtfs_rt_file_paths = sorted_map_gtfs_rt_file_paths
+
+    log_message(f'... found {files_no} files')
+    print()
 
     gtfs_controller = GTFS_Controller(app_path)
 
-    log_message(f'... found {len(gtfs_rt_file_paths)} files')
+    map_gtfs_dbs: dict[str, GTFS_DB] = {}
+    map_day_data_trips: dict[str, DayTripData] = {}
+    for file_day_f, gtfs_rt_file_paths in map_gtfs_rt_file_paths.items():
+        log_message(f'... DAY {file_day_f} -> {len(gtfs_rt_file_paths)} files')
+
+        for gtfs_rt_file_path in gtfs_rt_file_paths:
+            file_matches = re.match(file_match_regexp, gtfs_rt_file_path.name)
+            if file_matches is None:
+                continue
+        
+            file_date_f = file_matches[1]
+            file_hhmm = file_matches[2]
+            file_dt = datetime.strptime(f'{file_date_f} {file_hhmm}', '%Y-%m-%d %H%M')
+
+            gtfs_rt_json = load_json_from_file(gtfs_rt_file_path)
+            gtfs_rt_response = GTFS_RT_Response.from_gtfs_rt_json(gtfs_rt_json)
+
+            feed_version = gtfs_rt_response.header.feedVersion
+            gtfs_catalog_item = gtfs_controller.gtfs_dbs_report.lookup_by_feed_verson(feed_version)
+
+            if gtfs_catalog_item is None:
+                print(f'file: {gtfs_rt_file_path.name} => cant find GTFS DB for {feed_version}')
+                continue
+
+            gtfs_day = gtfs_catalog_item.gtfs_day
+            if gtfs_day not in map_gtfs_dbs:
+                log_message(f'... loading GTFS DB for {gtfs_day}')
+                gtfs_db = gtfs_controller.load_gtfs_db(gtfs_catalog_item)
+                if gtfs_db is None:
+                    print(gtfs_catalog_item)
+                    raise ValueError(f'cant load DB {gtfs_day} for known catalog item')
+                
+                map_gtfs_dbs[gtfs_day] = gtfs_db
+            # 
+            gtfs_db = map_gtfs_dbs[gtfs_day]
+
+            day_data_key = f'{gtfs_day}-{file_day_f}'
+            if day_data_key not in map_day_data_trips:
+                log_message(f'... loading GTFS day trips for DB:{gtfs_day} in day:{file_day_f}')
+                file_day = datetime.strptime(file_day_f, '%Y-%m-%d').date()
+                day_data_trips = gtfs_db.compute_day_data(file_day)
+                map_day_data_trips[day_data_key] = day_data_trips
+            #
+            day_data_trips = map_day_data_trips[day_data_key]
+
+            gtfs_controller.compare_gtfs_rt_from_file(
+                gtfs_rt_response, file_dt, gtfs_rt_file_path, 
+                gtfs_catalog_item, 
+                gtfs_db, 
+                day_data_trips,
+            )
+        # loop files
+        log_message('... done day')
+        print()
+    # loop days
     print()
 
-    file_idx = 0
-    map_gtfs_dbs: Dict[str, GTFS_DB] = {}
-    for gtfs_rt_file_path in gtfs_rt_file_paths:
-        file_matches = re.match(file_match_regexp, gtfs_rt_file_path.name)
-        if file_matches is None:
-            continue
-        
-        file_date_f = file_matches[1]
-        file_hhmm = file_matches[2]
-        file_dt = datetime.strptime(f'{file_date_f} {file_hhmm}', '%Y-%m-%d %H%M')
-
-        gtfs_rt_json = load_json_from_file(gtfs_rt_file_path)
-        gtfs_rt_response = GTFS_RT_Response.from_gtfs_rt_json(gtfs_rt_json)
-
-        feed_version = gtfs_rt_response.header.feedVersion
-        gtfs_catalog_item = gtfs_controller.gtfs_dbs_report.lookup_by_feed_verson(feed_version)
-
-        if gtfs_catalog_item is None:
-            continue
-
-        gtfs_day = gtfs_catalog_item.gtfs_day
-        if gtfs_day not in map_gtfs_dbs:
-            log_message(f'... loading GTFS DB for {gtfs_day}')
-            gtfs_db = gtfs_controller.load_gtfs_db(gtfs_catalog_item)
-            if gtfs_db is None:
-                print(gtfs_catalog_item)
-                raise ValueError(f'cant load DB {gtfs_day} for known catalog item')
-            
-            map_gtfs_dbs[gtfs_day] = gtfs_db
-        # 
-        gtfs_db = map_gtfs_dbs[gtfs_day]
-
-        if file_idx % 10 == 0:
-            log_message(f'... PROCESSING {file_idx} / {len(gtfs_rt_file_paths)}: {gtfs_rt_file_path.name}')
-        gtfs_controller.compare_gtfs_rt_from_file(file_dt, gtfs_rt_file_path, gtfs_catalog_item, gtfs_db)
-
-        file_idx += 1
-    # loop files
-    
     log_message('DONE LOOP')
 
 if __name__ == "__main__":

--- a/tools/gtfs-rt-static-compare/compare_gtfs_rt_static/gtfs_controller.py
+++ b/tools/gtfs-rt-static-compare/compare_gtfs_rt_static/gtfs_controller.py
@@ -46,8 +46,8 @@ class GTFS_Controller:
     def load_gtfs_db(self, gtfs_catalog_item: GTFS_Static_Catalog_Item):
         return self._load_gtfs_db(gtfs_catalog_item)
     
-    def compare_gtfs_rt_from_file(self, gtfs_rt_response: GTFS_RT_Response, gtfs_rt_file_dt: datetime, gtfs_rt_path: Path, gtfs_catalog_item: GTFS_Static_Catalog_Item, gtfs_db: GTFS_DB, day_data_trips: DayTripData):
-        self._compare_gtfs_rt_from_file(gtfs_rt_response, gtfs_rt_file_dt, gtfs_rt_path, gtfs_catalog_item, gtfs_db, day_data_trips)
+    def compare_gtfs_rt_from_file(self, gtfs_rt_response: GTFS_RT_Response, gtfs_rt_file_dt: datetime, gtfs_rt_path: Path, gtfs_catalog_item: GTFS_Static_Catalog_Item, day_data_trips: DayTripData):
+        self._compare_gtfs_rt_from_file(gtfs_rt_response, gtfs_rt_file_dt, gtfs_rt_path, gtfs_catalog_item, day_data_trips)
         
     def compute_gtfs_db_dt(self, dt: datetime):
         return self._compute_gtfs_db_catalog_item(dt)
@@ -99,7 +99,6 @@ class GTFS_Controller:
             fetch_dt,  
             gtfs_rt_snapshot_path, gtfs_rt_response, 
             gtfs_catalog_item, 
-            gtfs_db,
             day_data_trips,
         )
         
@@ -151,11 +150,10 @@ class GTFS_Controller:
 
         return gtfs_db
     
-    def _compare_gtfs_rt_from_file(self, gtfs_rt_response: GTFS_RT_Response, gtfs_rt_file_dt: datetime, gtfs_rt_path: Path, gtfs_catalog_item: GTFS_Static_Catalog_Item, gtfs_db: GTFS_DB, day_data_trips: DayTripData):
+    def _compare_gtfs_rt_from_file(self, gtfs_rt_response: GTFS_RT_Response, gtfs_rt_file_dt: datetime, gtfs_rt_path: Path, gtfs_catalog_item: GTFS_Static_Catalog_Item, day_data_trips: DayTripData):
         self._compare_file_gtfs_rt_static(
             gtfs_rt_file_dt, gtfs_rt_path, gtfs_rt_response,
             gtfs_catalog_item,
-            gtfs_db,
             day_data_trips,
         )
         
@@ -216,7 +214,6 @@ class GTFS_Controller:
     def _compare_file_gtfs_rt_static(self, 
             report_dt: datetime, gtfs_rt_path: Path, gtfs_rt_response: GTFS_RT_Response, 
             gtfs_catalog_item: GTFS_Static_Catalog_Item,
-            gtfs_db: GTFS_DB,
             day_data_trips: DayTripData,
         ):
         gtfs_rt_dt = datetime.fromtimestamp(gtfs_rt_response.header.timestamp)

--- a/tools/gtfs-rt-static-compare/compare_gtfs_rt_static/gtfs_controller.py
+++ b/tools/gtfs-rt-static-compare/compare_gtfs_rt_static/gtfs_controller.py
@@ -24,26 +24,11 @@ from .fetch import fetch_latest, compute_resource_snapshot_path
 gtfs_rt_static_report_file_regexp = r"gtfs_rt_static_report-([0-9]{4})-([0-9]{2})-([0-9]{2})-([0-9]{2})([0-9]{2})"
 header_separator_s = '-' * 60
 
-def normalize_if_overflow(t: str) -> tuple[str, bool]:
-    """
-    Detect if a time string (HH:MM:SS) exceeds 23:59:59.
-    If overflow, return normalized time (wrapped to next day) and True.
-    Otherwise, return original time and False.
-    """
-    h, m, s = map(int, t.split(':'))
-    total_seconds = h * 3600 + m * 60 + s
 class GTFS_ActiveTripsData(TypedDict):
     trips_no: int
     map_trip_ids: dict[str, bool]
     map_by_agency: dict[str, int]
 
-    if total_seconds >= 24 * 3600:
-        total_seconds %= 24 * 3600
-        h, rem = divmod(total_seconds, 3600)
-        m, s = divmod(rem, 60)
-        return f'{h:02d}:{m:02d}:{s:02d}', True
-    else:
-        return t, False
 class GTFS_Controller:
     gtfs_dbs_report: GTFS_Static_Catalog_Report
 

--- a/tools/gtfs-rt-static-compare/compare_gtfs_rt_static/gtfs_controller.py
+++ b/tools/gtfs-rt-static-compare/compare_gtfs_rt_static/gtfs_controller.py
@@ -33,6 +33,10 @@ def normalize_if_overflow(t: str) -> tuple[str, bool]:
     """
     h, m, s = map(int, t.split(':'))
     total_seconds = h * 3600 + m * 60 + s
+class GTFS_ActiveTripsData(TypedDict):
+    trips_no: int
+    map_trip_ids: dict[str, bool]
+    map_by_agency: dict[str, int]
 
     if total_seconds >= 24 * 3600:
         total_seconds %= 24 * 3600

--- a/tools/gtfs-rt-static-compare/compare_gtfs_rt_static/gtfs_controller.py
+++ b/tools/gtfs-rt-static-compare/compare_gtfs_rt_static/gtfs_controller.py
@@ -61,8 +61,8 @@ class GTFS_Controller:
     def load_gtfs_db(self, gtfs_catalog_item: GTFS_Static_Catalog_Item):
         return self._load_gtfs_db(gtfs_catalog_item)
     
-    def compare_gtfs_rt_from_file(self, gtfs_rt_file_dt: datetime, gtfs_rt_path: Path, gtfs_catalog_item: GTFS_Static_Catalog_Item, gtfs_db: GTFS_DB):
-        self._compare_gtfs_rt_from_file(gtfs_rt_file_dt, gtfs_rt_path, gtfs_catalog_item, gtfs_db)
+    def compare_gtfs_rt_from_file(self, gtfs_rt_response: GTFS_RT_Response, gtfs_rt_file_dt: datetime, gtfs_rt_path: Path, gtfs_catalog_item: GTFS_Static_Catalog_Item, gtfs_db: GTFS_DB, day_data_trips: DayTripData):
+        self._compare_gtfs_rt_from_file(gtfs_rt_response, gtfs_rt_file_dt, gtfs_rt_path, gtfs_catalog_item, gtfs_db, day_data_trips)
         
     def compute_gtfs_db_dt(self, dt: datetime):
         return self._compute_gtfs_db_catalog_item(dt)
@@ -107,11 +107,15 @@ class GTFS_Controller:
         
         log_message(f'... DONE LOAD DB')
         print(header_separator_s)
+
+        day_data_trips = gtfs_db.compute_day_data(fetch_dt.date())
         
         report = self._compare_file_gtfs_rt_static(
             fetch_dt,  
             gtfs_rt_snapshot_path, gtfs_rt_response, 
-            gtfs_catalog_item, gtfs_db
+            gtfs_catalog_item, 
+            gtfs_db,
+            day_data_trips,
         )
         
         print()
@@ -156,20 +160,18 @@ class GTFS_Controller:
             print('WHOOPS - cant find DB at path')
             print(gtfs_db_path)
             return None
-
-        gtfs_db = GTFS_DB(db_path=gtfs_db_path, resources_path_config=self.app_config['resource_paths'])
-        gtfs_db.init_lookups()
         
+        gtfs_db = GTFS_DB(db_path=gtfs_db_path, map_resource_paths=self.app_config['resource_paths'])
+        gtfs_db.init_lookups()
+
         return gtfs_db
     
-    def _compare_gtfs_rt_from_file(self, gtfs_rt_file_dt: datetime, gtfs_rt_path: Path, gtfs_catalog_item: GTFS_Static_Catalog_Item, gtfs_db: GTFS_DB):
-        gtfs_rt_json = load_json_from_file(gtfs_rt_path)
-        gtfs_rt_response = GTFS_RT_Response.from_gtfs_rt_json(gtfs_rt_json)
-        
+    def _compare_gtfs_rt_from_file(self, gtfs_rt_response: GTFS_RT_Response, gtfs_rt_file_dt: datetime, gtfs_rt_path: Path, gtfs_catalog_item: GTFS_Static_Catalog_Item, gtfs_db: GTFS_DB, day_data_trips: DayTripData):
         self._compare_file_gtfs_rt_static(
             gtfs_rt_file_dt, gtfs_rt_path, gtfs_rt_response,
             gtfs_catalog_item,
-            gtfs_db
+            gtfs_db,
+            day_data_trips,
         )
         
     def _compute_gtfs_db_catalog_item(self, dt: datetime) -> Union[GTFS_Static_Catalog_Item, None]:
@@ -230,6 +232,7 @@ class GTFS_Controller:
             report_dt: datetime, gtfs_rt_path: Path, gtfs_rt_response: GTFS_RT_Response, 
             gtfs_catalog_item: GTFS_Static_Catalog_Item,
             gtfs_db: GTFS_DB,
+            day_data_trips: DayTripData,
         ):
         gtfs_rt_dt = datetime.fromtimestamp(gtfs_rt_response.header.timestamp)
 
@@ -240,7 +243,13 @@ class GTFS_Controller:
         
         gtfs_db_dt = datetime.strptime(gtfs_catalog_item.gtfs_datetime_s, '%Y-%m-%d %H:%M')
         gtfs_db_age = round((gtfs_rt_dt.timestamp() - gtfs_db_dt.timestamp()) / (3600 * 24), 2)
-        
+
+        report_gtfs_active_trips_data: GTFS_TripsActiveData = {
+            'gtfs_day': gtfs_catalog_item.gtfs_day,
+            'trips_active_no': gtfs_active_trips_data['trips_no'],
+            'trips_active_by_agency': gtfs_active_trips_data['map_by_agency'],
+        }
+
         report_metdata = GTFS_RT_Static_Report_Metadata(
             report_dt=report_dt,
             gtfs_db_filename=compute_gtfs_db_filename(gtfs_static_day),
@@ -258,10 +267,15 @@ class GTFS_Controller:
             tripOK_routeNOK_no=0,
             tripNOK_routeOK_no=0,
             tripNOK_routeNOK_no=0,
-            tripNOK_NOJP_no=0
+            tripNOK_NOJP_no=0,
         )
-        
-        report_stats = GTFS_RT_Static_Report.init_with_metadata(report_metdata)
+
+        report_stats = GTFS_RT_Static_Report.init_with_metadata(
+            report_metdata, 
+            gtfs_rt_by_agency={},
+            gtfs_rt_active_by_agency={},
+            gtfs_trips_active_data=report_gtfs_active_trips_data
+        )
         
         for entity in gtfs_rt_response.entity:
             report_stats.metadata.total_rows_no += 1
@@ -269,22 +283,28 @@ class GTFS_Controller:
             trip_id = entity.tripUpdate.trip.tripId
             route_id = entity.tripUpdate.trip.routeId
             
-            trip_OK = trip_id in gtfs_db.map_trips
-            route_OK = route_id in gtfs_db.map_routes
+            # is the trip in the GTFS day trips?
+            trip_OK = trip_id in day_data_trips['map_trips']
             
-            entity_start_date_s = entity.tripUpdate.trip.startDate
-            if int(entity_start_date_s) == -1:
-                yesterday_date = datetime.now() - timedelta(days=1)
-                entity_start_date_s = yesterday_date.strftime('%Y%m%d')
-            
-            from_date_start_time, overflow = normalize_if_overflow(entity.tripUpdate.trip.startTime)
-            from_date_f = entity_start_date_s + ' ' +  from_date_start_time
-            from_date = datetime.strptime(from_date_f, '%Y%m%d %H:%M:%S')
-            if overflow:
-                # catch '20250930 24:01:00' ->
-                from_date = from_date + timedelta(days=1)
-            if from_date < report_dt:
+            # is the route present in actual GTFS?
+            route_OK = route_id in day_data_trips['map_route_agency']
+
+            agency_id = 'n_a'
+            if route_OK:
+                agency_id = day_data_trips['map_route_agency'][route_id]
+
+            if agency_id not in report_stats.gtfs_rt_by_agency:
+                report_stats.gtfs_rt_by_agency[agency_id] = 0
+            report_stats.gtfs_rt_by_agency[agency_id] += 1
+
+            is_trip_active = trip_id in gtfs_active_trips_data['map_trip_ids']
+            if is_trip_active:
                 report_stats.metadata.total_active_rows_no += 1
+
+                if agency_id not in report_stats.gtfs_rt_active_by_agency:
+                    report_stats.gtfs_rt_active_by_agency[agency_id] = 0
+                report_stats.gtfs_rt_active_by_agency[agency_id] += 1
+            # endif is_trip_active
             
             if trip_OK and route_OK:
                 report_stats.metadata.tripOK_routeOK_no += 1
@@ -306,7 +326,7 @@ class GTFS_Controller:
             if not trip_OK and not special_trip_id_matches:
                 report_stats.metadata.tripNOK_NOJP_no += 1
         # loop entity
-        
+
         report_path = self.app_config['resource_paths']['gtfs_rt_static_report']
         report_path = compute_resource_snapshot_path(report_path, report_dt)
         report_json = report_stats.as_json()

--- a/tools/gtfs-rt-static-compare/compare_gtfs_rt_static/gtfs_controller.py
+++ b/tools/gtfs-rt-static-compare/compare_gtfs_rt_static/gtfs_controller.py
@@ -2,9 +2,9 @@ import os, sys
 
 from pathlib import Path
 
-from typing import Union
+from typing import TypedDict, Union
 
-from datetime import datetime, timedelta
+from datetime import datetime
 
 import gzip
 import shutil
@@ -13,12 +13,11 @@ from .helpers.config_helpers import load_yaml_config
 from .helpers.gtfs_helpers import compute_gtfs_db_filename
 from .helpers.json_helpers import load_json_from_file, export_json_to_file
 from .helpers.log_helpers import format_path, log_message
+from .gtfs_db import GTFS_DB, DayTripData
 
 from .models.gtfs_static_db_catalog import GTFS_Static_Catalog_Report, GTFS_Static_Catalog_Item
 from .models.gtfs_rt import GTFS_RT_Response
-from .models.gtfs_rt_static_report import GTFS_RT_Static_Report, GTFS_RT_Static_Report_Metadata
-
-from .gtfs_db import GTFS_DB
+from .models.gtfs_rt_static_report import GTFS_RT_Static_Report, GTFS_RT_Static_Report_Metadata, GTFS_TripsActiveData
 
 from .fetch import fetch_latest, compute_resource_snapshot_path
 

--- a/tools/gtfs-rt-static-compare/compare_gtfs_rt_static/gtfs_controller.py
+++ b/tools/gtfs-rt-static-compare/compare_gtfs_rt_static/gtfs_controller.py
@@ -192,12 +192,48 @@ class GTFS_Controller:
         
         return found_gtfs_db_item
     
+    def _compute_gtfs_active_trips_data(self, day_data_trips: DayTripData, for_dt: datetime) -> GTFS_ActiveTripsData:
+        for_dt_minutes = for_dt.hour * 60 + for_dt.minute
+        if for_dt.hour < 4:
+            for_dt_minutes += 24 * 60
+
+        gtfs_active_trips_data: GTFS_ActiveTripsData = {
+            'trips_no': 0,
+            'map_trip_ids': {},
+            'map_by_agency': {},
+        }
+
+        for trip_id, trip_data in day_data_trips['map_trips'].items():
+            # trip ended in the past
+            if trip_data['arr_mins'] < for_dt_minutes:
+                continue
+            # trip starts in the future
+            if trip_data['dep_mins'] > for_dt_minutes:
+                continue
+            
+            gtfs_active_trips_data['trips_no'] += 1
+            gtfs_active_trips_data['map_trip_ids'][trip_id] = True
+
+            route_id = trip_data['route_id']
+            agency_id = day_data_trips['map_route_agency'][route_id] or None
+            if agency_id is None:
+                raise ValueError(f'cant find agency for trip_id:{trip_id} + route_id:{route_id}')
+            
+            if agency_id not in gtfs_active_trips_data['map_by_agency']:
+                gtfs_active_trips_data['map_by_agency'][agency_id] = 0
+            gtfs_active_trips_data['map_by_agency'][agency_id] += 1
+        # loop trips
+        
+        return gtfs_active_trips_data
+    
     def _compare_file_gtfs_rt_static(self, 
             report_dt: datetime, gtfs_rt_path: Path, gtfs_rt_response: GTFS_RT_Response, 
             gtfs_catalog_item: GTFS_Static_Catalog_Item,
             gtfs_db: GTFS_DB,
         ):
         gtfs_rt_dt = datetime.fromtimestamp(gtfs_rt_response.header.timestamp)
+
+        gtfs_active_trips_data = self._compute_gtfs_active_trips_data(day_data_trips, for_dt=report_dt)
         
         gtfs_static_day = gtfs_catalog_item.gtfs_day
         gtfs_rt_age = round(gtfs_rt_dt.timestamp() - report_dt.timestamp())

--- a/tools/gtfs-rt-static-compare/compare_gtfs_rt_static/gtfs_db.py
+++ b/tools/gtfs-rt-static-compare/compare_gtfs_rt_static/gtfs_db.py
@@ -24,18 +24,28 @@ class GTFS_DB:
 
     _gtfs_static_query_cache_path: Path
 
+    start_day: date
     gtfs_day: date
     
     def __init__(self, db_path: Path, map_resource_paths: Dict[str, Any] = {}):
         self._db = SQLiteDBEngine(db_path)
         
         self.map_routes = {}
+        self.start_day = self._compute_start_date()
         self.gtfs_day = parse_gtfs_day(db_path.name)
 
         gtfs_static_query_cache_path_s = map_resource_paths.get('gtfs_static_query_cache_path', None)
         if gtfs_static_query_cache_path_s is None:
             raise ValueError(f'expected gtfs_static_query_cache_path path is not defined in config')
         self._gtfs_static_query_cache_path = Path(gtfs_static_query_cache_path_s)
+
+    def _compute_start_date(self):
+        sql = 'SELECT start_date FROM calendar LIMIT 1'
+        rows = self._db.query(sql)
+        start_date_s = rows[0]['start_date']
+        start_date = parse_gtfs_day(start_date_s)
+
+        return start_date
             
     def init_lookups(self):
         gtfs_routes_db = self._load_gtfs_table('routes', map_by_field='route_id')

--- a/tools/gtfs-rt-static-compare/compare_gtfs_rt_static/gtfs_db.py
+++ b/tools/gtfs-rt-static-compare/compare_gtfs_rt_static/gtfs_db.py
@@ -70,15 +70,15 @@ class GTFS_DB:
         
     def _load_gtfs_table(self, table_name: str, map_by_field: str):
         res_cache_path = None
-        if self._gtfs_db_table_cache_template is not None:
-            res_cache_path_s: str = f'{self._gtfs_db_table_cache_template}'
-            res_cache_path_s = res_cache_path_s.replace('[GTFS_FILENAME]', f'{self._db.db_path.name}')
-            res_cache_path_s = res_cache_path_s.replace('[TABLE_NAME]', table_name)
+        if self._gtfs_static_query_cache_path is not None:
+            db_day_f = format_day(self.gtfs_day)
+            res_cache_path_s = f'{self._gtfs_static_query_cache_path}/db_{db_day_f}__table_{table_name}.json'
             res_cache_path = Path(res_cache_path_s)
         
             if os.path.isfile(res_cache_path):
                 res_json = load_json_from_file(res_cache_path)
                 return res_json
+        # check cache
         
         sql = None
         if table_name == 'trips':

--- a/tools/gtfs-rt-static-compare/compare_gtfs_rt_static/gtfs_db.py
+++ b/tools/gtfs-rt-static-compare/compare_gtfs_rt_static/gtfs_db.py
@@ -103,3 +103,47 @@ class GTFS_DB:
             export_json_to_file(res_json, res_cache_path, pretty_print=True)
         
         return res_json
+
+    def compute_day_data(self, day: date) -> DayTripData:
+        db_day_f = format_day(self.gtfs_day)
+        gtfs_day_f = format_day(day)
+        data_cache_filename = f'trip_day_data__db_{db_day_f}__day_{gtfs_day_f}.json'
+        data_cache_path = Path(f'{self._gtfs_static_query_cache_path}/{data_cache_filename}')
+        if data_cache_path.exists():
+            data_json = json_helpers.load_json_from_file(data_cache_path)
+            return data_json
+
+        day_idx = (day - self.start_day).days
+
+        sql = self._map_sql_paths['select_active_trips_agency_rt_mode_light'].read_text()
+        sql = sql.replace('[DAY_IDX]', f'{day_idx}')
+
+        day_trip_data: DayTripData = {
+            'map_trips': {},
+            'map_route_agency': {},
+            'map_agency_ids': {},
+        }
+
+        cursor = self._db.get_cursor()
+        cursor.execute(sql)
+        for db_row in cursor:
+            trip_id = db_row['trip_id']
+            route_id = db_row['route_id']
+            agency_id = db_row['agency_id']
+            
+            trip_row: TripRow = {
+                'trip_id': trip_id,
+                'route_id': route_id,
+                'dep_mins': db_row['departure_day_minutes'],
+                'arr_mins': db_row['arrival_day_minutes'],
+            }
+
+            day_trip_data['map_trips'][trip_id] = trip_row
+            day_trip_data['map_route_agency'][route_id] = agency_id
+            day_trip_data['map_agency_ids'][agency_id] = True
+        # loop db_rows
+        cursor.close()
+
+        json_helpers.export_json_to_file(day_trip_data, data_cache_path, pretty_print=True)
+
+        return day_trip_data

--- a/tools/gtfs-rt-static-compare/compare_gtfs_rt_static/gtfs_db.py
+++ b/tools/gtfs-rt-static-compare/compare_gtfs_rt_static/gtfs_db.py
@@ -23,6 +23,7 @@ class GTFS_DB:
     map_trips: Dict[str, TripDB]
 
     _gtfs_static_query_cache_path: Path
+    _map_sql_paths: Dict[str, Path]
 
     start_day: date
     gtfs_day: date
@@ -38,6 +39,11 @@ class GTFS_DB:
         if gtfs_static_query_cache_path_s is None:
             raise ValueError(f'expected gtfs_static_query_cache_path path is not defined in config')
         self._gtfs_static_query_cache_path = Path(gtfs_static_query_cache_path_s)
+
+        self._map_sql_paths = {}
+        map_sql_paths = map_resource_paths.get('sql', {})
+        for key, path_s in map_sql_paths.items():
+            self._map_sql_paths[key] = Path(path_s)
 
     def _compute_start_date(self):
         sql = 'SELECT start_date FROM calendar LIMIT 1'

--- a/tools/gtfs-rt-static-compare/compare_gtfs_rt_static/gtfs_db.py
+++ b/tools/gtfs-rt-static-compare/compare_gtfs_rt_static/gtfs_db.py
@@ -13,6 +13,17 @@ from .helpers import json_helpers
 from .models.gtfs_static_db import Route as RouteDB
 from .models.gtfs_static_db import Trip as TripDB
 
+class TripRow(TypedDict):
+    trip_id: str
+    route_id: str
+    dep_mins: int
+    arr_mins: int
+
+class DayTripData(TypedDict):
+    map_trips: Dict[str, TripRow]
+    map_route_agency: Dict[str, str]
+    map_agency_ids: Dict[str, bool]
+
 def format_day(day: date) -> str:
     day_f = day.strftime('%Y-%m-%d')
     return day_f

--- a/tools/gtfs-rt-static-compare/compare_gtfs_rt_static/gtfs_db.py
+++ b/tools/gtfs-rt-static-compare/compare_gtfs_rt_static/gtfs_db.py
@@ -14,16 +14,18 @@ class GTFS_DB:
     _db: SQLiteDBEngine
     map_routes: Dict[str, RouteDB]
     map_trips: Dict[str, TripDB]
-    _gtfs_db_table_cache_template: Optional[str]
+
+    _gtfs_static_query_cache_path: Path
     
-    def __init__(self, db_path: Path, resources_path_config: Optional[Dict[str, str]]):
+    def __init__(self, db_path: Path, map_resource_paths: Dict[str, Any] = {}):
         self._db = SQLiteDBEngine(db_path)
         
         self.map_routes = {}
-        self.map_routes = {}
-        
-        if resources_path_config is not None:
-            self._gtfs_db_table_cache_template = resources_path_config.get('cache_gtfs_db_table', None)
+
+        gtfs_static_query_cache_path_s = map_resource_paths.get('gtfs_static_query_cache_path', None)
+        if gtfs_static_query_cache_path_s is None:
+            raise ValueError(f'expected gtfs_static_query_cache_path path is not defined in config')
+        self._gtfs_static_query_cache_path = Path(gtfs_static_query_cache_path_s)
             
     def init_lookups(self):
         gtfs_routes_db = self._load_gtfs_table('routes', map_by_field='route_id')

--- a/tools/gtfs-rt-static-compare/compare_gtfs_rt_static/gtfs_db.py
+++ b/tools/gtfs-rt-static-compare/compare_gtfs_rt_static/gtfs_db.py
@@ -2,7 +2,8 @@ import os, sys
 
 from pathlib import Path
 
-from typing import Dict, Optional
+from typing import Any, Dict, TypedDict
+from datetime import date
 
 from .helpers.json_helpers import load_json_from_file, export_json_to_file
 from .helpers.db_engine import SQLiteDBEngine

--- a/tools/gtfs-rt-static-compare/compare_gtfs_rt_static/gtfs_db.py
+++ b/tools/gtfs-rt-static-compare/compare_gtfs_rt_static/gtfs_db.py
@@ -7,6 +7,7 @@ from datetime import date
 
 from .helpers.json_helpers import load_json_from_file, export_json_to_file
 from .helpers.db_engine import SQLiteDBEngine
+from .helpers.gtfs_helpers import parse_gtfs_day
 
 from .models.gtfs_static_db import Route as RouteDB
 from .models.gtfs_static_db import Trip as TripDB
@@ -17,11 +18,14 @@ class GTFS_DB:
     map_trips: Dict[str, TripDB]
 
     _gtfs_static_query_cache_path: Path
+
+    gtfs_day: date
     
     def __init__(self, db_path: Path, map_resource_paths: Dict[str, Any] = {}):
         self._db = SQLiteDBEngine(db_path)
         
         self.map_routes = {}
+        self.gtfs_day = parse_gtfs_day(db_path.name)
 
         gtfs_static_query_cache_path_s = map_resource_paths.get('gtfs_static_query_cache_path', None)
         if gtfs_static_query_cache_path_s is None:

--- a/tools/gtfs-rt-static-compare/compare_gtfs_rt_static/gtfs_db.py
+++ b/tools/gtfs-rt-static-compare/compare_gtfs_rt_static/gtfs_db.py
@@ -8,6 +8,7 @@ from datetime import date
 from .helpers.json_helpers import load_json_from_file, export_json_to_file
 from .helpers.db_engine import SQLiteDBEngine
 from .helpers.gtfs_helpers import parse_gtfs_day
+from .helpers import json_helpers
 
 from .models.gtfs_static_db import Route as RouteDB
 from .models.gtfs_static_db import Trip as TripDB

--- a/tools/gtfs-rt-static-compare/compare_gtfs_rt_static/gtfs_db.py
+++ b/tools/gtfs-rt-static-compare/compare_gtfs_rt_static/gtfs_db.py
@@ -12,6 +12,10 @@ from .helpers.gtfs_helpers import parse_gtfs_day
 from .models.gtfs_static_db import Route as RouteDB
 from .models.gtfs_static_db import Trip as TripDB
 
+def format_day(day: date) -> str:
+    day_f = day.strftime('%Y-%m-%d')
+    return day_f
+
 class GTFS_DB:
     _db: SQLiteDBEngine
     map_routes: Dict[str, RouteDB]

--- a/tools/gtfs-rt-static-compare/compare_gtfs_rt_static/gtfs_db.py
+++ b/tools/gtfs-rt-static-compare/compare_gtfs_rt_static/gtfs_db.py
@@ -11,7 +11,6 @@ from .helpers.gtfs_helpers import parse_gtfs_day
 from .helpers import json_helpers
 
 from .models.gtfs_static_db import Route as RouteDB
-from .models.gtfs_static_db import Trip as TripDB
 
 class TripRow(TypedDict):
     trip_id: str

--- a/tools/gtfs-rt-static-compare/compare_gtfs_rt_static/gtfs_db.py
+++ b/tools/gtfs-rt-static-compare/compare_gtfs_rt_static/gtfs_db.py
@@ -31,7 +31,6 @@ def format_day(day: date) -> str:
 class GTFS_DB:
     _db: SQLiteDBEngine
     map_routes: Dict[str, RouteDB]
-    map_trips: Dict[str, TripDB]
 
     _gtfs_static_query_cache_path: Path
     _map_sql_paths: Dict[str, Path]
@@ -70,14 +69,6 @@ class GTFS_DB:
         for route_id, route_db_json in gtfs_routes_db.items():
             route_db_json_cleaned = {k: v for k, v in route_db_json.items() if k in RouteDB.__annotations__}
             self.map_routes[route_id] = RouteDB(**route_db_json_cleaned)        
-        
-        gtfs_trips_db = self._load_gtfs_table('trips', map_by_field='trip_id')
-        self.map_trips: dict[str, TripDB] = {}
-        for trip_id, trip_db_json in gtfs_trips_db.items():
-            trip_db_json_cleaned = {k: v for k, v in trip_db_json.items() if k in TripDB.__annotations__}
-            self.map_trips[trip_id] = TripDB(**trip_db_json_cleaned)
-            # Dont use Trip because is slower init
-            # self.map_trips[trip_id] = Trip.init_from_db_row(trip_db_json, gtfs_calendar_db, gtfs_agency_db, gtfs_routes_db, gtfs_stops_db)
         
     def _load_gtfs_table(self, table_name: str, map_by_field: str):
         res_cache_path = None

--- a/tools/gtfs-rt-static-compare/compare_gtfs_rt_static/sql/select_active_trips_agency_rt_mode_light.sql
+++ b/tools/gtfs-rt-static-compare/compare_gtfs_rt_static/sql/select_active_trips_agency_rt_mode_light.sql
@@ -1,0 +1,30 @@
+SELECT
+    trips.trip_id,
+    trips.route_id,
+    routes.agency_id,
+    departure_day_minutes,
+    arrival_day_minutes
+FROM trips, routes, link_agency, calendar
+WHERE
+    trips.route_id = routes.route_id
+    AND
+    routes.agency_id = link_agency.agency_id
+    AND
+    trips.service_id = calendar.service_id
+    AND
+    link_agency.has_gtfs_rt = 1
+    AND
+    (
+        -- current day trip
+        ( SUBSTR(calendar.day_bits, [DAY_IDX] + 1, 1) = '1' )
+        OR
+        -- check for prev day trip that are going over midnight
+        (
+            -- is after-midnight trip
+            ( trips.arrival_day_minutes > 24 * 60 )
+            -- prev day_bit is '1'
+            AND (SUBSTR(calendar.day_bits, [DAY_IDX], 1) = '1')
+            -- current day_bit is '0'
+            AND (SUBSTR(calendar.day_bits, [DAY_IDX] + 1, 1) = '0')
+        )
+    )

--- a/tools/gtfs-rt-static-compare/config/config.yml
+++ b/tools/gtfs-rt-static-compare/config/config.yml
@@ -4,7 +4,7 @@ resource_paths:
   gtfs_rt_snapshot: "[APP_PATH]/data/gtfs-rt-snapshot/[YEAR]/[MONTH]/[DAY]/GTFS_RT-[YEAR]-[MONTH]-[DAY]-[HHMM].json"
   gtfs_db: "[APP_PATH]/data/gtfs-static-dbs/[GTFS_FILENAME]"
   gtfs_dbs_json_path: "[APP_PATH]/data/gtfs-static-dbs/gtfs-static-dbs.json"
-  cache_gtfs_db_table: "[APP_PATH]/data/gtfs-rt-static-compare-tmp/[GTFS_FILENAME].[TABLE_NAME]-v1.json"
+  gtfs_static_query_cache_path: "[APP_PATH]/data/gtfs-rt-static-compare-tmp"
   gtfs_rt_static_report: "[APP_PATH]/data/gtfs-rt-static-compare-report/[YEAR]/[MONTH]/[DAY]/gtfs_rt_static_report-[YEAR]-[MONTH]-[DAY]-[HHMM].json"
   gtfs_rt_static_mo_json: "[APP_PATH]/data/gtfs-rt-static-compare-report/[YEAR]/gtfs_rt_static_report-[YEAR]-[MONTH].json"
 

--- a/tools/gtfs-rt-static-compare/config/config.yml
+++ b/tools/gtfs-rt-static-compare/config/config.yml
@@ -8,6 +8,9 @@ resource_paths:
   gtfs_rt_static_report: "[APP_PATH]/data/gtfs-rt-static-compare-report/[YEAR]/[MONTH]/[DAY]/gtfs_rt_static_report-[YEAR]-[MONTH]-[DAY]-[HHMM].json"
   gtfs_rt_static_mo_json: "[APP_PATH]/data/gtfs-rt-static-compare-report/[YEAR]/gtfs_rt_static_report-[YEAR]-[MONTH].json"
 
+  sql:
+    select_active_trips_agency_rt_mode_light: "[APP_PATH]/compare_gtfs_rt_static/sql/select_active_trips_agency_rt_mode_light.sql"
+
 opentransportdata:
   gtfs_rt_url: https://api.opentransportdata.swiss/la/gtfs-rt?format=JSON
 

--- a/tools/gtfs-static-db-importer/data/gtfs-db-lookups
+++ b/tools/gtfs-static-db-importer/data/gtfs-db-lookups
@@ -1,1 +1,0 @@
-../../../data/gtfs-db-lookups

--- a/tools/gtfs-static-db-importer/inc/config/gtfs_schema.yml
+++ b/tools/gtfs-static-db-importer/inc/config/gtfs_schema.yml
@@ -74,7 +74,7 @@ tables:
       - agency_id TEXT NOT NULL
       - route_short_name TEXT NOT NULL 
       - route_long_name TEXT
-      - route_desc TEXT NOT NULL
+      - route_desc TEXT
       - route_type INTEGER NOT NULL # extended codes, check https://opentransportdata.swiss/de/cookbook/timetable-cookbook/gtfs/
       - day_bits TEXT # similar with HRDF
       - representative_trip_id TEXT # the trip that occurs the most

--- a/tools/gtfs-static-db-importer/inc/db_importer.py
+++ b/tools/gtfs-static-db-importer/inc/db_importer.py
@@ -148,7 +148,7 @@ class GTFS_DB_Importer:
             if not os.path.isfile(gtfs_file_path):
                 is_skip_ok = False
 
-                if table_name == 'shapes':
+                if table_name in ['feed_info', 'frequencies', 'shapes', 'transfers']:
                     is_skip_ok = True
 
                 if table_name == 'calendar':

--- a/tools/scripts/cli_otd_compare_gtfs_rt_static.sh
+++ b/tools/scripts/cli_otd_compare_gtfs_rt_static.sh
@@ -13,6 +13,14 @@ LOGFILE=$LOGS_BASEPATH/otd_compare_gtfs_rt_static-$DATE_NOW.log
 touch "$LOGFILE"
 symlink_latest $LOGFILE
 
+DETAIL_REPORT_DATE_F=$(printf '%s\n' "$LOGFILE" | grep -Eo '[0-9]{4}-[0-9]{2}-[0-9]{2}-[0-9]{4}')
+DETAIL_REPORT_URL="https://tools.opentransportdata.swiss/gtfs-rt-static-report/detail/$DETAIL_REPORT_DATE_F.json"
+
+echo "GTFS-RT -static compare issue"
+echo "Report(overview)  : https://tools.opentransportdata.swiss/gtfs-rt-static-report/"
+echo "Report(by agency) : $DETAIL_REPORT_URL"
+echo ""
+
 echo "Step 1/2: running cli_compare_latest.py ..."
 $PYTHON_PATH $TOOL_FOLDER_PATH/cli_compare_latest.py >>"$LOGFILE"
 echo ""


### PR DESCRIPTION
- rely on `link_agency.has_gtfs_rt` field to check if an agency has GTFS-RT messages
- define GTFS-static active trips that start in the past and finish in the future from the moment of comparison (see below diagram)

<img width="920" height="559" alt="image" src="https://github.com/user-attachments/assets/d25737f3-ed4a-4cff-8b0c-9f1800e1047b" />

- improve GTFS-RT /- static comparison to show in detail page also delata differences between coverages in GTFS-RT  / -static. improve performance and load of the report data
- updates GTFS-static DB schema, allow to skip more not-needed tables

